### PR TITLE
Node config: lookup system NodeJsLocation property

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
@@ -58,6 +58,13 @@ public class InitializeLaunchConfigurations {
 	}
 
 	public static String getNodeJsLocation() {
+		{
+			String nodeJsLocation = System.getProperty("NodeJsLocation");
+			if (nodeJsLocation != null && Files.exists(Paths.get(nodeJsLocation))) {
+				return nodeJsLocation;
+			}
+		}
+		
 		String res = "/path/to/node";
 		String[] command = new String[] {"/bin/bash", "-c", "which node"};
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {


### PR DESCRIPTION
A simple (but powerful) way to allow the user to "select" the nodejs location.
The user can set NodeJsLocation property in the Eclipse.ini or in the command line parameters.
Product developers can set this property on the fly.

Signed-off-by: Arian Fornaris <boniatillo@gmail.com>