### PR TITLE
Support jsonc file types too.

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -33,7 +33,7 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.wildwebdeveloper.parent"
-            file-extensions="json"
+            file-extensions="json, jsonc"
             id="org.eclipse.wildwebdeveloper.json"
             name="JSON"
             priority="normal">


### PR DESCRIPTION
As per https://code.visualstudio.com/docs/languages/json if you have
*.jsonc file it is treated as json with comments and warnings about
comment are not shown. Add association to have it by default.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>