### PR TITLE
Do not monitor Debug Adapter launcher process by default

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/NodeAttachDebugDelegate.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/NodeAttachDebugDelegate.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.lsp4e.debug.DSPPlugin;
 import org.eclipse.lsp4e.debug.launcher.DSPLaunchDelegate;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.wildwebdeveloper.Activator;
@@ -58,7 +59,7 @@ public class NodeAttachDebugDelegate extends DSPLaunchDelegate {
 			DSPLaunchDelegateLaunchBuilder builder = new DSPLaunchDelegateLaunchBuilder(configuration, mode, launch,
 					monitor);
 			builder.setLaunchDebugAdapter(InitializeLaunchConfigurations.getNodeJsLocation(), debugCmdArgs);
-			builder.setMonitorDebugAdapter(true);
+			builder.setMonitorDebugAdapter(configuration.getAttribute(DSPPlugin.ATTR_DSP_MONITOR_DEBUG_ADAPTER, false));
 			builder.setDspParameters(param);
 
 			super.launch(builder);

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/NodeRunDAPDebugDelegate.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/NodeRunDAPDebugDelegate.java
@@ -32,6 +32,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.lsp4e.debug.DSPPlugin;
 import org.eclipse.lsp4e.debug.launcher.DSPLaunchDelegate;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.wildwebdeveloper.Activator;
@@ -88,7 +89,7 @@ public class NodeRunDAPDebugDelegate extends DSPLaunchDelegate {
 			DSPLaunchDelegateLaunchBuilder builder = new DSPLaunchDelegateLaunchBuilder(configuration, mode, launch,
 					monitor);
 			builder.setLaunchDebugAdapter(InitializeLaunchConfigurations.getNodeJsLocation(), debugCmdArgs);
-			builder.setMonitorDebugAdapter(true);
+			builder.setMonitorDebugAdapter(configuration.getAttribute(DSPPlugin.ATTR_DSP_MONITOR_DEBUG_ADAPTER, false));
 			builder.setDspParameters(param);
 
 			super.launch(builder);


### PR DESCRIPTION
this prevents from noisy messages in console.

Signed-off-by: Mickael Istria <mistria@redhat.com>