### PR TITLE
Change default debug Firefox shortcut to launch (not attach)

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -491,7 +491,7 @@
       </launchConfigurationType>
       <launchConfigurationType
             delegate="org.eclipse.wildwebdeveloper.debug.firefox.FirefoxRunDABDebugDelegate"
-            id="org.eclipse.wildwebdeveloper.launchConfigurationType1"
+            id="org.eclipse.wildwebdeveloper.runFirefoxDebug"
             modes="debug"
             name="Launch Firefox Debugger"
             public="true"
@@ -530,9 +530,9 @@
             icon="icons/firefoxIconSmall.png"
             id="org.eclipse.wildwebdeveloper.firefoxRunShortcut"
             label="Firefox"
-            modes="run,debug">
+            modes="debug">
          <configurationType
-               id="org.eclipse.wildwebdeveloper.launchConfiguration.firefoxDebug">
+               id="org.eclipse.wildwebdeveloper.runFirefoxDebug">
          </configurationType>
          <contextualLaunch>
             <enablement>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/firefox/FirefoxRunDABDebugDelegate.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/firefox/FirefoxRunDABDebugDelegate.java
@@ -38,7 +38,7 @@ import org.eclipse.wildwebdeveloper.InitializeLaunchConfigurations;
 
 public class FirefoxRunDABDebugDelegate extends DSPLaunchDelegate {
 
-	static final String ID = "org.eclipse.wildwebdeveloper.launchConfiguration.firefoxDebug"; //$NON-NLS-1$
+	static final String ID = "org.eclipse.wildwebdeveloper.runFirefoxDebug"; //$NON-NLS-1$
 
 	// see https://github.com/firefox-devtools/vscode-firefox-debug/blob/master/src/adapter/configuration.ts for launch/attach configuration parameters
 	static final String PORT = "port"; //$NON-NLS-1$


### PR DESCRIPTION
fix #245 