### PR TITLE
Make html projects debuggable with Firefox/Chrome on right-click menu

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -590,6 +590,10 @@
                   <iterate>
                      <adapt
                            type="org.eclipse.core.resources.IResource">
+                        <test
+                              forcePluginActivation="true"
+                              property="org.eclipse.wildwebdeveloper.isHTMLLaunchable">
+                        </test>
                      </adapt>
                   </iterate>
                </with>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/HTMLLaunchableAdapterFactory.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/HTMLLaunchableAdapterFactory.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.debug.ui.actions.ILaunchable;
 import org.eclipse.wildwebdeveloper.debug.firefox.FirefoxRunDebugLaunchShortcut;
 
-// Based off of https://github.com/eclipse/aCute/blob/master/org.eclipse.acute/src/org/eclipse/acute/IsLaunchableHTMLTester.java
+// Based off of https://github.com/eclipse/aCute/blob/master/org.eclipse.acute/src/org/eclipse/acute/Tester.java
 
 public class HTMLLaunchableAdapterFactory implements IAdapterFactory {
 
@@ -33,8 +33,6 @@ public class HTMLLaunchableAdapterFactory implements IAdapterFactory {
 			IResource resource = Adapters.adapt(adaptableObject, IResource.class);
 			if  (new FirefoxRunDebugLaunchShortcut().canLaunch(resource.getLocation().toFile())) {
 				return adapterType.cast(DUMMY);
-			
-			
 		}
 
 		return null;

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/IsLaunchableHTMLTester.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/IsLaunchableHTMLTester.java
@@ -26,7 +26,7 @@ public class IsLaunchableHTMLTester extends PropertyTester {
 			if (resource == null) {
 				return false;
 			}
-			return new FirefoxRunDebugLaunchShortcut().canLaunch(resource.getLocation().toFile());
+			return new FirefoxRunDebugLaunchShortcut().canLaunchResource(resource);
 		}
 		return false;
 	}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDebugLaunchShortcut.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/chrome/ChromeRunDebugLaunchShortcut.java
@@ -22,6 +22,7 @@ import org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut;
 import org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugDelegate;
 
 public class ChromeRunDebugLaunchShortcut extends AbstractDebugAdapterLaunchShortcut {
+	
 	public ChromeRunDebugLaunchShortcut() {
 		super(ChromeRunDAPDebugDelegate.ID, "org.eclipse.wildwebdeveloper.html");
 	}


### PR DESCRIPTION
Make both html projects and folder debuggable with Firefox and Chrome on right-click -> Debug as...

To be debugged, the project or folder must have either a index.html or a single .html file in it's root.

Fix #258

Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>