### PR TITLE
Make bash act as if invoked as a login shell

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Mickael Istria (Red Hat Inc.) - initial implementation
+ *   Pierre-Yves B. - Issue #238 Why does wildweb do "/bin/bash -c which node" ?
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.tests;
 
@@ -83,7 +84,7 @@ public class TestAngular {
 
 	public static String getNpmLocation() {
 		String res = "/path/to/npm";
-		String[] command = new String[] { "/bin/bash", "-c", "which npm" };
+		String[] command = new String[] { "/bin/bash", "-c", "-l", "which npm" };
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {
 			command = new String[] { "cmd", "/c", "where npm" };
 		}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
@@ -11,6 +11,7 @@
  *   Mickael Istria (Red Hat Inc.) - initial implementation
  *   Gautier de Saint Martin Lacaze - Issue #55 Warn missing or incompatible node.js
  *   Pierre-Yves B. - Issue #196 NullPointerException when validating Node.js version
+ *   Pierre-Yves B. - Issue #238 Why does wildweb do "/bin/bash -c which node" ?
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper;
 
@@ -69,11 +70,11 @@ public class InitializeLaunchConfigurations {
 		return null;
 	}
 
-	public static String which(String progrgam) {
+	public static String which(String program) {
 		String res = null;
-		String[] command = new String[] { "/bin/bash", "-c", "which " + progrgam};
+		String[] command = new String[] { "/bin/bash", "-c", "-l", "which " + program};
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {
-			command = new String[] { "cmd", "/c", "where " + progrgam };
+			command = new String[] { "cmd", "/c", "where " + program };
 		}
 		try (BufferedReader reader = new BufferedReader(
 				new InputStreamReader(Runtime.getRuntime().exec(command).getInputStream()));) {


### PR DESCRIPTION
This is a follow up to #238. Indeed, Wild Web Developer does not work properly on my macOS Mojave machine. Node.js 10.16.3 is part of my `PATH` variable specified in my _.profile_ file, however, as documented [here](https://stackoverflow.com/a/55716895/3527464), the `-l` option needs to be specified to make sure it is picked up when executing the shell from within Eclipse.

Signed-off-by: PyvesB <PyvesDev@gmail.com>