### PR TITLE
Avoid double-testing for node's existance.

### DIFF
--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.7.0.qualifier"
+      version="0.7.1.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.7.0-SNAPSHOT</version>
+	<version>0.7.1-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.0.qualifier
+Bundle-Version: 0.5.1.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.5.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/InitializeLaunchConfigurations.java
@@ -51,11 +51,12 @@ public class InitializeLaunchConfigurations {
 
 		String res = which("node");
 		if (res == null) {
-			res = getDefaultNodePath();
+			if (Files.exists(Paths.get(getDefaultNodePath()))) {
+				res = getDefaultNodePath();
+			}
 		}
 
-		if (Files.exists(Paths.get(res))) {
-
+		if (res != null) {
 			validateNodeVersion(res);
 
 			return res;


### PR DESCRIPTION
If 'which' yields a positive result then we know that the exe
exists and there no need to test it again for existance.

Signed-off-by: Mat Booth <mat.booth@redhat.com>