### PR TITLE
Update to LSP4J 0.9.0 with its API breaking changes for DAP 1.37 and LSP 3.15

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="wildwebdeveloper" sequenceNumber="11">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="wildwebdeveloper" sequenceNumber="12">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="https://download.eclipse.org/eclipse/updates/4.14/"/>
@@ -17,17 +17,25 @@
 	<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.xtend.lib" version="0.0.0"/>
 	<!--unit id="org.eclipse.lsp4e" version="0.0.0"/>
-	<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/-->
+	<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/
 	<unit id="org.eclipse.lsp4j" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4j.generator" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/> 
-	<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/> 
+	<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>-->
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<repository location="https://download.eclipse.org/lsp4e/releases/0.13.0/"/>
+	<repository location="https://download.eclipse.org/lsp4e/snapshots/"/>
 	<unit id="org.eclipse.lsp4e" version="0.0.0"/>
 	<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+	<repository location="https://download.eclipse.org/lsp4j/updates/milestones/S202001301830/"/>
+	<unit id="org.eclipse.lsp4j" version="0.0.0"/>
+	<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+	<unit id="org.eclipse.lsp4j.generator" version="0.0.0"/>
+	<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
+	<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="http://download.eclipse.org/cbi/updates/license/"/>


### PR DESCRIPTION
AFAICT WildWebDeveloper is fine with 0.9.0 of LSP4J and its API changes.

When I run on my machine I get:

```
Failures: 
  TestLanguageServers.testJSONFile:129 Diagnostic not published

Tests run: 23, Failures: 1, Errors: 0, Skipped: 0
```

which is the same with or without the update to newer LSP4J.