### PR TITLE
Maven builds updates

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml/pom.xml
@@ -26,7 +26,6 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
-				<version>1.4.2</version>
 				<executions>
 					<execution>
 						<id>fetch-xml</id>

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -29,7 +29,6 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
-				<version>1.4.1</version>
 				<executions>
 					<execution>
 						<id>fetch-vscode</id>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
 					<artifactId>maven-clean-plugin</artifactId>
 					<version>3.1.0</version>
 				</plugin>
+				<plugin>
+					<groupId>com.googlecode.maven-download-plugin</groupId>
+					<artifactId>download-maven-plugin</artifactId>
+					<version>1.5.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -179,7 +184,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.5</version>
+						<version>1.1.7</version>
 						<executions>
 							<execution>
 								<id>sign</id>


### PR DESCRIPTION
* Update cbi plugin to 1.1.7
* Define single download-maven-plugin and use it everywhere instead of
each plugin using different version
* Update download-maven-plugin to 1.5.0

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>