### PR TITLE
DRAFT: A Simple JSP editor

### DIFF
--- a/org.eclipse.wildwebdeveloper/grammars/java/java.tmLanguage.json
+++ b/org.eclipse.wildwebdeveloper/grammars/java/java.tmLanguage.json
@@ -1,0 +1,1622 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/atom/language-java/blob/master/grammars/java.cson",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/atom/language-java/commit/ed8ad7451b4d0454374885a102dbe63befdea509",
+	"name": "Java",
+	"scopeName": "source.java",
+	"patterns": [
+		{
+			"begin": "\\b(package)\\b\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.package.java"
+				}
+			},
+			"end": "\\s*(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.java"
+				}
+			},
+			"name": "meta.package.java",
+			"contentName": "storage.modifier.package.java",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"match": "(?<=\\.)\\s*\\.|\\.(?=\\s*;)",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!_)_(?=\\s*(\\.|;))|\\b\\d+|-+",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "[A-Z]+",
+					"name": "invalid.deprecated.package_name_not_lowercase.java"
+				},
+				{
+					"match": "(?x)\\b(?<!\\$)\n(abstract|assert|boolean|break|byte|case|catch|char|class|\nconst|continue|default|do|double|else|enum|extends|final|\nfinally|float|for|goto|if|implements|import|instanceof|int|\ninterface|long|native|new|package|private|protected|public|\nreturn|short|static|strictfp|super|switch|syncronized|this|\nthrow|throws|transient|try|void|volatile|while|\ntrue|false|null)\\b",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.java"
+				}
+			]
+		},
+		{
+			"begin": "\\b(import)\\b\\s*\\b(static)?\\b\\s",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.import.java"
+				},
+				"2": {
+					"name": "storage.modifier.java"
+				}
+			},
+			"end": "\\s*(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.java"
+				}
+			},
+			"name": "meta.import.java",
+			"contentName": "storage.modifier.import.java",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"match": "(?<=\\.)\\s*\\.|\\.(?=\\s*;)",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!\\.)\\s*\\*",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!_)_(?=\\s*(\\.|;))|\\b\\d+|-+",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?x)\\b(?<!\\$)\n(abstract|assert|boolean|break|byte|case|catch|char|class|\nconst|continue|default|do|double|else|enum|extends|final|\nfinally|float|for|goto|if|implements|import|instanceof|int|\ninterface|long|native|new|package|private|protected|public|\nreturn|short|static|strictfp|super|switch|syncronized|this|\nthrow|throws|transient|try|void|volatile|while|\ntrue|false|null)\\b",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.java"
+				},
+				{
+					"match": "\\*",
+					"name": "variable.language.wildcard.java"
+				}
+			]
+		},
+		{
+			"include": "#comments-javadoc"
+		},
+		{
+			"include": "#code"
+		},
+		{
+			"include": "#module"
+		}
+	],
+	"repository": {
+		"all-types": {
+			"patterns": [
+				{
+					"include": "#primitive-arrays"
+				},
+				{
+					"include": "#primitive-types"
+				},
+				{
+					"include": "#object-types"
+				}
+			]
+		},
+		"annotations": {
+			"patterns": [
+				{
+					"begin": "((@)\\s*([^\\s(]+))(\\()",
+					"beginCaptures": {
+						"2": {
+							"name": "punctuation.definition.annotation.java"
+						},
+						"3": {
+							"name": "storage.type.annotation.java"
+						},
+						"4": {
+							"name": "punctuation.definition.annotation-arguments.begin.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.annotation-arguments.end.bracket.round.java"
+						}
+					},
+					"name": "meta.declaration.annotation.java",
+					"patterns": [
+						{
+							"captures": {
+								"1": {
+									"name": "constant.other.key.java"
+								},
+								"2": {
+									"name": "keyword.operator.assignment.java"
+								}
+							},
+							"match": "(\\w*)\\s*(=)"
+						},
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"match": "(@)(interface)\\s+(\\w*)|((@)\\s*(\\w+))",
+					"name": "meta.declaration.annotation.java",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.annotation.java"
+						},
+						"2": {
+							"name": "storage.modifier.java"
+						},
+						"3": {
+							"name": "storage.type.annotation.java"
+						},
+						"5": {
+							"name": "punctuation.definition.annotation.java"
+						},
+						"6": {
+							"name": "storage.type.annotation.java"
+						}
+					}
+				}
+			]
+		},
+		"anonymous-block-and-instance-initializer": {
+			"begin": "{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.block.begin.bracket.curly.java"
+				}
+			},
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.block.end.bracket.curly.java"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"anonymous-classes-and-new": {
+			"begin": "\\bnew\\b",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.control.new.java"
+				}
+			},
+			"end": "(?=;|\\)|,|:|}|\\+|\\-|\\*|\\/|%|!|&|\\||=)",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"begin": "(?<!\\])\\s*({)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.section.inner-class.begin.bracket.curly.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.inner-class.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.inner-class.java",
+					"patterns": [
+						{
+							"include": "#class-body"
+						}
+					]
+				},
+				{
+					"include": "#parens"
+				}
+			]
+		},
+		"assertions": {
+			"patterns": [
+				{
+					"begin": "\\b(assert)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.assert.java"
+						}
+					},
+					"end": "$",
+					"name": "meta.declaration.assertion.java",
+					"patterns": [
+						{
+							"match": ":",
+							"name": "keyword.operator.assert.expression-separator.java"
+						},
+						{
+							"include": "#code"
+						}
+					]
+				}
+			]
+		},
+		"class": {
+			"begin": "(?=\\w?[\\w\\s]*\\b(?:class|(?<!@)interface|enum)\\s+\\w+)",
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.class.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.class.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "storage.modifier.java"
+						},
+						"2": {
+							"name": "entity.name.type.class.java"
+						}
+					},
+					"match": "(class|(?<!@)interface|enum)\\s+(\\w+)",
+					"name": "meta.class.identifier.java"
+				},
+				{
+					"begin": "extends",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.modifier.extends.java"
+						}
+					},
+					"end": "(?={|implements)",
+					"name": "meta.definition.class.inherited.classes.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "(implements)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.implements.java"
+						}
+					},
+					"end": "(?=\\s*extends|\\{)",
+					"name": "meta.definition.class.implemented.interfaces.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.class.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.class.body.java",
+					"patterns": [
+						{
+							"include": "#class-body"
+						}
+					]
+				}
+			]
+		},
+		"class-body": {
+			"patterns": [
+				{
+					"include": "#comments-javadoc"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#enums"
+				},
+				{
+					"include": "#class"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#static-initializer"
+				},
+				{
+					"include": "#class-fields-and-methods"
+				},
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#member-variables"
+				},
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"class-fields-and-methods": {
+			"patterns": [
+				{
+					"begin": "(?=\\=)",
+					"end": "(?=;)",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"include": "#methods"
+				}
+			]
+		},
+		"code": {
+			"patterns": [
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#enums"
+				},
+				{
+					"include": "#class"
+				},
+				{
+					"include": "#anonymous-block-and-instance-initializer"
+				},
+				{
+					"include": "#try-catch-finally"
+				},
+				{
+					"include": "#assertions"
+				},
+				{
+					"include": "#parens"
+				},
+				{
+					"include": "#constants-and-special-vars"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"include": "#anonymous-classes-and-new"
+				},
+				{
+					"include": "#lambda-expression"
+				},
+				{
+					"include": "#keywords"
+				},
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#method-call"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#variables-local"
+				},
+				{
+					"include": "#objects"
+				},
+				{
+					"include": "#properties"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.period.java"
+				},
+				{
+					"match": ";",
+					"name": "punctuation.terminator.java"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"match": "/\\*\\*/",
+					"name": "comment.block.empty.java"
+				},
+				{
+					"include": "#comments-inline"
+				}
+			]
+		},
+		"comments-inline": {
+			"patterns": [
+				{
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.java"
+				},
+				{
+					"begin": "(^[ \\t]+)?(?=//)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.java"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": [
+						{
+							"begin": "//",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.java"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-slash.java"
+						}
+					]
+				}
+			]
+		},
+		"comments-javadoc": {
+			"patterns": [
+				{
+					"begin": "^\\s*(/\\*\\*)(?!/)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"name": "comment.block.javadoc.java",
+					"patterns": [
+						{
+							"match": "@(author|deprecated|return|see|serial|since|version)\\b",
+							"name": "keyword.other.documentation.javadoc.java"
+						},
+						{
+							"match": "(@param)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "variable.parameter.java"
+								}
+							}
+						},
+						{
+							"match": "(@(?:exception|throws))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "entity.name.type.class.java"
+								}
+							}
+						},
+						{
+							"match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "entity.name.type.class.java"
+								},
+								"3": {
+									"name": "variable.parameter.java"
+								}
+							}
+						}
+					]
+				}
+			]
+		},
+		"constants-and-special-vars": {
+			"patterns": [
+				{
+					"match": "\\b(true|false|null)\\b",
+					"name": "constant.language.java"
+				},
+				{
+					"match": "\\bthis\\b",
+					"name": "variable.language.this.java"
+				},
+				{
+					"match": "\\bsuper\\b",
+					"name": "variable.language.java"
+				}
+			]
+		},
+		"enums": {
+			"begin": "^\\s*([\\w\\s]*)(enum)\\s+(\\w+)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#storage-modifiers"
+						}
+					]
+				},
+				"2": {
+					"name": "storage.modifier.java"
+				},
+				"3": {
+					"name": "entity.name.type.enum.java"
+				}
+			},
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.enum.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.enum.java",
+			"patterns": [
+				{
+					"begin": "\\b(extends)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.extends.java"
+						}
+					},
+					"end": "(?={|\\bimplements\\b)",
+					"name": "meta.definition.class.inherited.classes.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "\\b(implements)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.implements.java"
+						}
+					},
+					"end": "(?={|\\bextends\\b)",
+					"name": "meta.definition.class.implemented.interfaces.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.enum.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"patterns": [
+						{
+							"begin": "(?<={)",
+							"end": "(?=;|})",
+							"patterns": [
+								{
+									"include": "#comments-javadoc"
+								},
+								{
+									"include": "#comments"
+								},
+								{
+									"begin": "(\\w+)\\s*({)",
+									"beginCaptures": {
+										"1": {
+											"name": "constant.other.enum.java"
+										},
+										"2": {
+											"name": "punctuation.bracket.curly.java"
+										}
+									},
+									"end": "\\}",
+									"endCaptures": {
+										"0": {
+											"name": "punctuation.bracket.curly.java"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#class-body"
+										}
+									]
+								},
+								{
+									"begin": "(\\w+)\\s*(\\()",
+									"beginCaptures": {
+										"1": {
+											"name": "constant.other.enum.java"
+										},
+										"2": {
+											"name": "punctuation.bracket.round.java"
+										}
+									},
+									"end": "\\)",
+									"endCaptures": {
+										"0": {
+											"name": "punctuation.bracket.round.java"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#code"
+										}
+									]
+								},
+								{
+									"match": "\\b\\w+\\b",
+									"name": "constant.other.enum.java"
+								}
+							]
+						},
+						{
+							"include": "#class-body"
+						}
+					]
+				}
+			]
+		},
+		"function-call": {
+			"begin": "([A-Za-z_$][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.java"
+				},
+				"2": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.java"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.java"
+				}
+			},
+			"name": "meta.function-call.java",
+			"patterns": [
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"generics": {
+			"begin": "<",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.bracket.angle.java"
+				}
+			},
+			"end": ">",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.bracket.angle.java"
+				}
+			},
+			"patterns": [
+				{
+					"match": "\\b(extends|super)\\b",
+					"name": "storage.modifier.$1.java"
+				},
+				{
+					"match": "(?<!\\.)([a-zA-Z$_][a-zA-Z0-9$_]*)(?=\\s*<)",
+					"captures": {
+						"1": {
+							"name": "storage.type.java"
+						}
+					}
+				},
+				{
+					"include": "#primitive-arrays"
+				},
+				{
+					"match": "[a-zA-Z$_][a-zA-Z0-9$_]*",
+					"name": "storage.type.generic.java"
+				},
+				{
+					"match": "\\?",
+					"name": "storage.type.generic.wildcard.java"
+				},
+				{
+					"match": "&",
+					"name": "punctuation.separator.types.java"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.period.java"
+				},
+				{
+					"include": "#parens"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"match": "\\bthrow\\b",
+					"name": "keyword.control.throw.java"
+				},
+				{
+					"match": "\\?|:",
+					"name": "keyword.control.ternary.java"
+				},
+				{
+					"match": "\\b(return|break|case|continue|default|do|while|for|switch|if|else)\\b",
+					"name": "keyword.control.java"
+				},
+				{
+					"match": "\\b(instanceof)\\b",
+					"name": "keyword.operator.instanceof.java"
+				},
+				{
+					"match": "(<<|>>>?|~|\\^)",
+					"name": "keyword.operator.bitwise.java"
+				},
+				{
+					"match": "((&|\\^|\\||<<|>>>?)=)",
+					"name": "keyword.operator.assignment.bitwise.java"
+				},
+				{
+					"match": "(===?|!=|<=|>=|<>|<|>)",
+					"name": "keyword.operator.comparison.java"
+				},
+				{
+					"match": "([+*/%-]=)",
+					"name": "keyword.operator.assignment.arithmetic.java"
+				},
+				{
+					"match": "(=)",
+					"name": "keyword.operator.assignment.java"
+				},
+				{
+					"match": "(\\-\\-|\\+\\+)",
+					"name": "keyword.operator.increment-decrement.java"
+				},
+				{
+					"match": "(\\-|\\+|\\*|\\/|%)",
+					"name": "keyword.operator.arithmetic.java"
+				},
+				{
+					"match": "(!|&&|\\|\\|)",
+					"name": "keyword.operator.logical.java"
+				},
+				{
+					"match": "(\\||&)",
+					"name": "keyword.operator.bitwise.java"
+				},
+				{
+					"match": "\\b(const|goto)\\b",
+					"name": "keyword.reserved.java"
+				}
+			]
+		},
+		"lambda-expression": {
+			"patterns": [
+				{
+					"match": "->",
+					"name": "storage.type.function.arrow.java"
+				}
+			]
+		},
+		"member-variables": {
+			"begin": "(?=private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final)",
+			"end": "(?=\\=|;)",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#primitive-arrays"
+				},
+				{
+					"include": "#object-types"
+				}
+			]
+		},
+		"method-call": {
+			"begin": "(\\.)\\s*([A-Za-z_$][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.separator.period.java"
+				},
+				"2": {
+					"name": "entity.name.function.java"
+				},
+				"3": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.java"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.java"
+				}
+			},
+			"name": "meta.method-call.java",
+			"patterns": [
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"methods": {
+			"begin": "(?!new)(?=[\\w<].*\\s+)(?=([^=/]|/(?!/))+\\()",
+			"end": "(})|(?=;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.method.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.method.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"begin": "(\\w+)\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.java"
+						},
+						"2": {
+							"name": "punctuation.definition.parameters.begin.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.parameters.end.bracket.round.java"
+						}
+					},
+					"name": "meta.method.identifier.java",
+					"patterns": [
+						{
+							"include": "#parameters"
+						},
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"begin": "(?=\\w.*\\s+\\w+\\s*\\()",
+					"end": "(?=\\s+\\w+\\s*\\()",
+					"name": "meta.method.return-type.java",
+					"patterns": [
+						{
+							"include": "#all-types"
+						},
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#throws"
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.method.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.method.body.java",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"module": {
+			"begin": "((open)\\s)?(module)\\s+(\\w+)",
+			"end": "}",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.java"
+				},
+				"3": {
+					"name": "storage.modifier.java"
+				},
+				"4": {
+					"name": "entity.name.type.module.java"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.module.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.module.java",
+			"patterns": [
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.module.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.module.body.java",
+					"patterns": [
+						{
+							"match": "\\b(requires|transitive|exports|opens|to|uses|provides|with)\\b",
+							"name": "keyword.module.java"
+						}
+					]
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"match": "(?x)\n\\b(?<!\\$)\n0(x|X)\n(\n  (?<!\\.)[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?[Ll]?(?!\\.)\n  |\n  (\n    [0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\\.?\n    |\n    ([0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?)?\\.[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\n  )\n  [Pp][+-]?[0-9]([0-9_]*[0-9])?[FfDd]?\n)\n\\b(?!\\$)",
+					"name": "constant.numeric.hex.java"
+				},
+				{
+					"match": "\\b(?<!\\$)0(b|B)[01]([01_]*[01])?[Ll]?\\b(?!\\$)",
+					"name": "constant.numeric.binary.java"
+				},
+				{
+					"match": "\\b(?<!\\$)0[0-7]([0-7_]*[0-7])?[Ll]?\\b(?!\\$)",
+					"name": "constant.numeric.octal.java"
+				},
+				{
+					"match": "(?x)\n(?<!\\$)\n(\n  \\b[0-9]([0-9_]*[0-9])?\\.\\B(?!\\.)\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([0-9]([0-9_]*[0-9])?)([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  (?<!\\.)\\B\\.[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b(0|[1-9]([0-9_]*[0-9])?)(?!\\.)[Ll]?\\b\n)\n(?!\\$)",
+					"name": "constant.numeric.decimal.java"
+				}
+			]
+		},
+		"object-types": {
+			"patterns": [
+				{
+					"include": "#generics"
+				},
+				{
+					"begin": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*)([A-Z_]\\w*)\\s*(?=\\[)",
+					"beginCaptures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						},
+						"2": {
+							"name": "storage.type.object.array.java"
+						}
+					},
+					"end": "(?!\\s*\\[)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#parens"
+						}
+					]
+				},
+				{
+					"match": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*[A-Z_]\\w*)\\s*(?=<)",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						}
+					}
+				},
+				{
+					"match": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*[A-Z_]\\w*)\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"object-types-inherited": {
+			"patterns": [
+				{
+					"include": "#generics"
+				},
+				{
+					"match": "\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b",
+					"name": "entity.other.inherited-class.java",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				}
+			]
+		},
+		"objects": {
+			"match": "(?<![\\w$])[a-zA-Z_$][\\w$]*(?=\\s*\\.\\s*[\\w$]+)",
+			"name": "variable.other.object.java"
+		},
+		"parameters": {
+			"patterns": [
+				{
+					"match": "\\bfinal\\b",
+					"name": "storage.modifier.java"
+				},
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"match": "\\w+",
+					"name": "variable.parameter.java"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.\\.\\.",
+					"name": "punctuation.definition.parameters.varargs.java"
+				}
+			]
+		},
+		"parens": {
+			"patterns": [
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.round.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"begin": "\\[",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.square.java"
+						}
+					},
+					"end": "\\]",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.square.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.curly.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.curly.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				}
+			]
+		},
+		"primitive-arrays": {
+			"patterns": [
+				{
+					"begin": "\\b(void|boolean|byte|char|short|int|float|long|double)\\b\\s*(?=\\[)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.primitive.array.java"
+						}
+					},
+					"end": "(?!\\s*\\[)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#parens"
+						}
+					]
+				}
+			]
+		},
+		"primitive-types": {
+			"match": "\\b(void|boolean|byte|char|short|int|float|long|double)\\b",
+			"name": "storage.type.primitive.java"
+		},
+		"properties": {
+			"patterns": [
+				{
+					"match": "(\\.)\\s*([a-zA-Z_$][\\w$]*)(?=\\s*\\.\\s*[a-zA-Z_$][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "variable.other.object.property.java"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([a-zA-Z_$][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "variable.other.property.java"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([0-9][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "invalid.illegal.identifier.java"
+						}
+					}
+				}
+			]
+		},
+		"static-initializer": {
+			"patterns": [
+				{
+					"include": "#anonymous-block-and-instance-initializer"
+				},
+				{
+					"match": "static",
+					"name": "storage.modifier.java"
+				}
+			]
+		},
+		"storage-modifiers": {
+			"match": "\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp)\\b",
+			"name": "storage.modifier.java"
+		},
+		"strings": {
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
+					"name": "string.quoted.double.java",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escape.java"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
+					"end": "'",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
+					"name": "string.quoted.single.java",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escape.java"
+						}
+					]
+				}
+			]
+		},
+		"throws": {
+			"begin": "throws",
+			"beginCaptures": {
+				"0": {
+					"name": "storage.modifier.java"
+				}
+			},
+			"end": "(?={|;)",
+			"name": "meta.throwables.java",
+			"patterns": [
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "[a-zA-Z$_][\\.a-zA-Z0-9$_]*",
+					"name": "storage.type.java"
+				}
+			]
+		},
+		"try-catch-finally": {
+			"patterns": [
+				{
+					"begin": "\\btry\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.try.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.try.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.try.java",
+					"patterns": [
+						{
+							"begin": "\\(",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.try.resources.begin.bracket.round.java"
+								}
+							},
+							"end": "\\)",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.section.try.resources.end.bracket.round.java"
+								}
+							},
+							"name": "meta.try.resources.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						},
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.try.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.try.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "\\b(catch)\\b\\s*(?=\\(\\s*[^\\s]+\\s*[^)]+\\))",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.catch.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.catch.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.catch.java",
+					"patterns": [
+						{
+							"begin": "\\(",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.parameters.begin.bracket.round.java"
+								}
+							},
+							"end": "\\)",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.definition.parameters.end.bracket.round.java"
+								}
+							},
+							"contentName": "meta.catch.parameters.java",
+							"patterns": [
+								{
+									"include": "#comments"
+								},
+								{
+									"include": "#storage-modifiers"
+								},
+								{
+									"match": "\\|",
+									"name": "punctuation.catch.separator.java"
+								},
+								{
+									"match": "([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?",
+									"captures": {
+										"1": {
+											"name": "storage.type.java"
+										},
+										"2": {
+											"name": "variable.parameter.java"
+										}
+									}
+								}
+							]
+						},
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.catch.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.catch.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "\\bfinally\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.finally.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.finally.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.finally.java",
+					"patterns": [
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.finally.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.finally.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"variables": {
+			"begin": "(?x)\n(?=\n  (\n    \\b(void|boolean|byte|char|short|int|float|long|double)\\b\n    |\n    (?>(\\w+\\.)*[A-Z_]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`\n  )\n  \\s*\n  (\n    <[\\w<>,\\.?\\s\\[\\]]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`\n  )?\n  \\s*\n  (\n    (\\[\\])* # int[][]\n  )?\n  \\s+\n  [A-Za-z_$][\\w$]* # At least one identifier after space\n  ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers\n  \\s*(=|:|;)\n)",
+			"end": "(?=\\=|:|;)",
+			"name": "meta.definition.variable.java",
+			"patterns": [
+				{
+					"match": "([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|:|=|,))",
+					"captures": {
+						"1": {
+							"name": "variable.other.definition.java"
+						}
+					}
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"variables-local": {
+			"begin": "(?=\\b(var)\\b\\s+[A-Za-z_$][\\w$]*\\s*(=|:|;))",
+			"end": "(?=\\=|:|;)",
+			"name": "meta.definition.variable.local.java",
+			"patterns": [
+				{
+					"match": "\\bvar\\b",
+					"name": "storage.type.local.java"
+				},
+				{
+					"match": "([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(=|:|;))",
+					"captures": {
+						"1": {
+							"name": "variable.other.definition.java"
+						}
+					}
+				},
+				{
+					"include": "#code"
+				}
+			]
+		}
+	}
+}

--- a/org.eclipse.wildwebdeveloper/grammars/jsp/jsp.tmLanguage.json
+++ b/org.eclipse.wildwebdeveloper/grammars/jsp/jsp.tmLanguage.json
@@ -1,0 +1,1203 @@
+{
+    "fileTypes": [
+        "jsp",
+        "jspf",
+        "tag"
+    ],
+    "injections": {
+        "text.html.jsp - (meta.embedded.block.jsp | meta.embedded.line.jsp | meta.tag | comment), meta.tag string.quoted": {
+            "patterns": [
+                {
+                    "include": "#comment"
+                },
+                {
+                    "include": "#declaration"
+                },
+                {
+                    "include": "#expression"
+                },
+                {
+                    "include": "#el_expression"
+                },
+                {
+                    "include": "#tags"
+                },
+                {
+                    "begin": "(^\\s*)(?=<%(?=\\s))",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.whitespace.embedded.leading.erb"
+                        }
+                    },
+                    "end": "(?!\\G)(\\s*$\\n)?",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.whitespace.embedded.trailing.erb"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#scriptlet"
+                        }
+                    ]
+                },
+                {
+                    "include": "#scriptlet"
+                }
+            ]
+        }
+    },
+    "keyEquivalent": "^~J",
+    "name": "JavaServer Pages",
+    "patterns": [
+        {
+            "include": "#xml_tags"
+        },
+        {
+            "include": "text.html.basic"
+        }
+    ],
+    "repository": {
+        "comment": {
+            "begin": "<%--",
+            "captures": {
+                "0": {
+                    "name": "punctuation.definition.comment.jsp"
+                }
+            },
+            "end": "--%>",
+            "name": "comment.block.jsp"
+        },
+        "declaration": {
+            "begin": "<%!",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.jsp"
+                }
+            },
+            "contentName": "source.java",
+            "end": "(%)>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.jsp"
+                },
+                "1": {
+                    "name": "source.java"
+                }
+            },
+            "name": "meta.embedded.line.declaration.jsp",
+            "patterns": [
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        "el_expression": {
+            "begin": "\\$\\{",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.jsp"
+                }
+            },
+            "contentName": "source.java",
+            "end": "(\\})",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.jsp"
+                },
+                "1": {
+                    "name": "source.java"
+                }
+            },
+            "name": "meta.embedded.line.el_expression.jsp",
+            "patterns": [
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        "expression": {
+            "begin": "<%=",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.jsp"
+                }
+            },
+            "contentName": "source.java",
+            "end": "(%)>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.jsp"
+                },
+                "1": {
+                    "name": "source.java"
+                }
+            },
+            "name": "meta.embedded.line.expression.jsp",
+            "patterns": [
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        "scriptlet": {
+            "begin": "<%",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.jsp"
+                }
+            },
+            "contentName": "source.java",
+            "end": "(%)>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.jsp"
+                },
+                "1": {
+                    "name": "source.java"
+                }
+            },
+            "name": "meta.embedded.block.scriptlet.jsp",
+            "patterns": [
+                {
+                    "match": "\\{",
+                    "name": "punctuation.section.scope.begin.java"
+                },
+                {
+                    "match": "\\}",
+                    "name": "punctuation.section.scope.end.java"
+                },
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        "tags": {
+            "begin": "(<%@)\\s*(?=(attribute|include|page|tag|taglib|variable)\\s)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.begin.jsp"
+                }
+            },
+            "end": "%>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.tag.end.jsp"
+                }
+            },
+            "name": "meta.tag.template.include.jsp",
+            "patterns": [
+                {
+                    "begin": "\\G(attribute)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.attribute.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(name|required|fragment|rtexprvalue|type|description)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\G(include)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.include.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(file)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\G(page)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.page.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(language|extends|import|session|buffer|autoFlush|isThreadSafe|info|errorPage|isErrorPage|contentType|pageEncoding|isElIgnored)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\G(tag)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.tag.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(display-name|body-content|dynamic-attributes|small-icon|large-icon|description|example|language|import|pageEncoding|isELIgnored)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\G(taglib)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.taglib.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(uri|tagdir|prefix)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\G(variable)(?=\\s)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.variable.jsp"
+                        }
+                    },
+                    "end": "(?=%>)",
+                    "patterns": [
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.jsp"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.jsp"
+                                },
+                                "3": {
+                                    "name": "string.quoted.double.jsp"
+                                },
+                                "4": {
+                                    "name": "punctuation.definition.string.begin.jsp"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.jsp"
+                                }
+                            },
+                            "match": "(name-given|alias|variable-class|declare|scope|description)(=)((\")[^\"]*(\"))"
+                        }
+                    ]
+                }
+            ]
+        },
+        "xml_tags": {
+            "patterns": [
+                {
+                    "begin": "(^\\s*)(?=<jsp:(declaration|expression|scriptlet)>)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.whitespace.embedded.leading.erb"
+                        }
+                    },
+                    "end": "(?!\\G)(\\s*$\\n)?",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.whitespace.embedded.trailing.erb"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#embedded"
+                        }
+                    ]
+                },
+                {
+                    "include": "#embedded"
+                },
+                {
+                    "include": "#directive"
+                },
+                {
+                    "include": "#actions"
+                }
+            ],
+            "repository": {
+                "actions": {
+                    "patterns": [
+                        {
+                            "begin": "(</?)(jsp:attribute)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.attribute.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name|trim)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "match": "(</?)(jsp:body)(>)",
+                            "name": "meta.tag.template.body.jsp"
+                        },
+                        {
+                            "begin": "(</?)(jsp:element)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.element.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:doBody)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.dobody.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(var|varReader|scope)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(</?)(jsp:forward)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/?>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.forward.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(page)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:param)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.param.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name|value)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:getProperty)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.getproperty.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name|property)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(</?)(jsp:include)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/?>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.include.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(page|flush)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:invoke)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.invoke.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(fragment|var|varReader|scope)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:output)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.output.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(omit-xml-declaration|doctype-root-element|doctype-system|doctype-public)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(</?)(jsp:plugin)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.plugin.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(type|code|codebase|name|archive|align|height|hspace|jreversion|nspluginurl|iepluginurl)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "match": "(</?)(jsp:fallback)(>)",
+                            "name": "meta.tag.template.fallback.jsp"
+                        },
+                        {
+                            "begin": "(</?)(jsp:root)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.root.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(xmlns|version|xmlns:taglibPrefix)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "(<)(jsp:setProperty)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.setproperty.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name|property|value)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "captures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "end": ">",
+                            "match": "(</?)(jsp:text)(>)",
+                            "name": "meta.tag.template.text.jsp"
+                        },
+                        {
+                            "begin": "(</?)(jsp:useBean)\\b",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.tag.begin.jsp"
+                                },
+                                "2": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "/?>",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.tag.end.jsp"
+                                }
+                            },
+                            "name": "meta.tag.template.usebean.jsp",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(id|scope|class|type|beanName)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "directive": {
+                    "begin": "(<)(jsp:directive\\.(?=(attribute|include|page|tag|variable)\\s))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.begin.jsp"
+                        },
+                        "2": {
+                            "name": "entity.name.tag.jsp"
+                        }
+                    },
+                    "end": "/>",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.tag.end.jsp"
+                        }
+                    },
+                    "name": "meta.tag.template.$3.jsp",
+                    "patterns": [
+                        {
+                            "begin": "\\G(attribute)(?=\\s)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "(?=/>)",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name|required|fragment|rtexprvalue|type|description)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "\\G(include)(?=\\s)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "(?=/>)",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(file)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "\\G(page)(?=\\s)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "(?=/>)",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(language|extends|import|session|buffer|autoFlush|isThreadSafe|info|errorPage|isErrorPage|contentType|pageEncoding|isElIgnored)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "\\G(tag)(?=\\s)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "(?=/>)",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(display-name|body-content|dynamic-attributes|small-icon|large-icon|description|example|language|import|pageEncoding|isELIgnored)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        },
+                        {
+                            "begin": "\\G(variable)(?=\\s)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.name.tag.jsp"
+                                }
+                            },
+                            "end": "(?=/>)",
+                            "patterns": [
+                                {
+                                    "captures": {
+                                        "1": {
+                                            "name": "entity.other.attribute-name.jsp"
+                                        },
+                                        "2": {
+                                            "name": "punctuation.separator.key-value.jsp"
+                                        },
+                                        "3": {
+                                            "name": "string.quoted.double.jsp"
+                                        },
+                                        "4": {
+                                            "name": "punctuation.definition.string.begin.jsp"
+                                        },
+                                        "5": {
+                                            "name": "punctuation.definition.string.end.jsp"
+                                        }
+                                    },
+                                    "match": "(name-given|alias|variable-class|declare|scope|description)(=)((\")[^\"]*(\"))"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "embedded": {
+                    "begin": "(<)(jsp:(declaration|expression|scriptlet))(>)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "meta.tag.template.$3.jsp"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.tag.begin.jsp"
+                        },
+                        "2": {
+                            "name": "entity.name.tag.jsp"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.tag.end.jsp"
+                        }
+                    },
+                    "contentName": "source.java",
+                    "end": "((<)/)(jsp:\\3)(>)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "meta.tag.template.$4.jsp"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.tag.begin.jsp"
+                        },
+                        "2": {
+                            "name": "source.java"
+                        },
+                        "3": {
+                            "name": "entity.name.tag.jsp"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.tag.end.jsp"
+                        }
+                    },
+                    "name": "meta.embedded.block.jsp",
+                    "patterns": [
+                        {
+                            "include": "source.java"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "scopeName": "text.html.jsp",
+    "uuid": "FFF2D8D5-6282-45DF-A508-5C254E29FFC2"
+}

--- a/org.eclipse.wildwebdeveloper/language-configurations/java/java-configuration.json
+++ b/org.eclipse.wildwebdeveloper/language-configurations/java/java-configuration.json
@@ -1,0 +1,33 @@
+{
+	"comments": {
+		"lineComment": "//",
+		"blockComment": [ "/*", "*/" ]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "'", "close": "'" },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
+	],
+	"surroundingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "'", "close": "'" },
+		{ "open": "<", "close": ">" }
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))",
+			"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
+		}
+	}
+}

--- a/org.eclipse.wildwebdeveloper/language-configurations/jsp/jsp-configuration.json
+++ b/org.eclipse.wildwebdeveloper/language-configurations/jsp/jsp-configuration.json
@@ -1,0 +1,28 @@
+{
+	"comments": {
+		"blockComment": [ "<%--", "--%>" ]
+	},
+	"brackets": [
+		[ "<!--", "-->" ],
+		[ "<%--", "--%>" ],
+		[ "<", ">" ],
+		[ "{", "}" ],
+		[ "(", ")" ]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" }
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" },
+		{ "open": "<%", "close": "%>" }
+	]
+}

--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -389,6 +389,61 @@
      <icon contentType="org.eclipse.wildwebdeveloper.ts" icon="icons/tsEditorIcon.png"/>
    </extension>
 
+   <!-- Java Server Pages (JSP) -->   
+   <extension
+         point="org.eclipse.core.contenttype.contentTypes">
+      <content-type
+            base-type="org.eclipse.wildwebdeveloper.parent"
+            file-extensions="jsp,jspf,tag"
+            id="org.eclipse.wildwebdeveloper.jsp"
+            name="JavaServerPages"
+            priority="normal">
+      </content-type>
+   </extension>
+
+   <extension
+         point="org.eclipse.lsp4e.languageServer">
+      <server
+            class="org.eclipse.wildwebdeveloper.html.HTMLLanguageServer"
+            id="org.eclipse.wildwebdeveloper.jsp-ls"
+            label="JavaServer Pages Language Server"
+            singleton="true">
+      </server>
+      <contentTypeMapping
+            contentType="org.eclipse.wildwebdeveloper.jsp"
+            id="org.eclipse.wildwebdeveloper.jsp-ls">
+      </contentTypeMapping>
+   </extension>
+   
+   <extension
+         point="org.eclipse.tm4e.registry.grammars">
+      <grammar
+            path="grammars/jsp/jsp.tmLanguage.json"
+            scopeName="text.html.jsp"/>
+      <scopeNameContentTypeBinding
+            contentTypeId="org.eclipse.wildwebdeveloper.jsp"
+            scopeName="text.html.jsp"/>
+       <grammar
+            path="grammars/java/java.tmLanguage.json"
+            scopeName="source.java"/>
+      <scopeNameContentTypeBinding
+            contentTypeId="org.eclipse.wildwebdeveloper.jsp"
+            scopeName="source.java"/>
+             
+   </extension>   
+ 
+   <extension
+         point="org.eclipse.tm4e.languageconfiguration.languageConfigurations">
+      <languageConfiguration
+            contentTypeId="org.eclipse.wildwebdeveloper.jsp"
+            path="language-configurations/jsp/jsp-configuration.json">
+      </languageConfiguration>
+   </extension>
+   
+   <extension point="org.eclipse.ui.genericeditor.icons">
+     <icon contentType="org.eclipse.wildwebdeveloper.jsp" icon="icons/jsEditorIcon.png"/>
+   </extension>
+   
    <!-- Angular -->
    <extension point="org.eclipse.lsp4e.languageServer">
      <server id="org.eclipse.wildwebdeveloper.angular" class="org.eclipse.wildwebdeveloper.angular.AngularLanguageServer" label="Angular Language Server"/>


### PR DESCRIPTION
Provides the editing facility for *.jsp", "*.jspf" and "*.tag" files,
Provides:
- For HTML content type: syntax highlighting, content assist and error reporting (via 'HTMLLanguageServer')
- For Java content type: syntax highlighting only

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>