### PR TITLE
Bug 559907 - Consider opening js files with GenericEditor/WildWebDeve…

### DIFF
--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.9.0.qualifier"
+      version="0.9.1.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.9.1-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.6.qualifier
+Bundle-Version: 0.5.7.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -476,6 +476,14 @@
    </extension>
 
    <extension
+      point="org.eclipse.ui.ide.editorAssociationOverride">
+         <editorAssociationOverride
+            id="org.eclipse.wildwebdeveloper.JSEditorAssociationOverride"
+            class="org.eclipse.wildwebdeveloper.JSEditorAssociationOverride">
+         </editorAssociationOverride>
+   </extension>
+
+   <extension
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
             delegate="org.eclipse.wildwebdeveloper.debug.node.NodeRunDAPDebugDelegate"

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.6-SNAPSHOT</version>
+	<version>0.5.7-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/JSEditorAssociationOverride.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/JSEditorAssociationOverride.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Victor Rubezhny (Red Hat Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorRegistry;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
+import org.eclipse.ui.internal.genericeditor.GenericEditorWithContentTypeIcon;
+import org.eclipse.ui.internal.genericeditor.GenericEditorWithIconAssociationOverride;
+
+public class JSEditorAssociationOverride extends GenericEditorWithIconAssociationOverride {
+	private final IEditorDescriptor genericEditorWithJSIcon;
+	private final IContentType wildWebDeveloperJSContentType;
+
+	public JSEditorAssociationOverride() {
+		IEditorRegistry editorReg = PlatformUI.getWorkbench().getEditorRegistry();
+		IEditorDescriptor genericEditorDescriptor = editorReg.findEditor(ExtensionBasedTextEditor.GENERIC_EDITOR_ID);
+		genericEditorWithJSIcon = genericEditorDescriptor != null ? new GenericEditorWithContentTypeIcon("*.js", genericEditorDescriptor) : null;
+		wildWebDeveloperJSContentType = Platform.getContentTypeManager().getContentType("org.eclipse.wildwebdeveloper.js");
+	}
+	
+	@Override
+	public IEditorDescriptor overrideDefaultEditor(IEditorInput editorInput, IContentType contentType,
+			IEditorDescriptor editorDescriptor) {
+		return editorInput != null ? overrideDefaultEditor(editorInput.getName(), contentType, editorDescriptor)
+				: editorDescriptor;
+	}
+	
+	// Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=559907
+	@Override
+	public IEditorDescriptor overrideDefaultEditor(String fileName, IContentType contentType,
+			IEditorDescriptor editorDescriptor) {
+		if (wildWebDeveloperJSContentType != null && genericEditorWithJSIcon != null) {
+			if(wildWebDeveloperJSContentType.equals(contentType) || 
+					wildWebDeveloperJSContentType.isAssociatedWith(fileName)) { 
+				return genericEditorWithJSIcon;
+			}
+		}
+		return super.overrideDefaultEditor(fileName, contentType, editorDescriptor);
+	}
+}


### PR DESCRIPTION
…loper by default

The PR adds a workaroung that makes Generic Text Editor to be a default editor for "*.js" files on a new workspace. 

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>