### PR TITLE
Issue #418: Use default user shell on macOS to find node

### DIFF
--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.9.1.qualifier"
+      version="0.10.1.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.9.1-SNAPSHOT</version>
+	<version>0.10.1-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.xml.feature"
       label="%name"
-      version="0.9.1.qualifier"
+      version="0.10.1.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.xml.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.9.1-SNAPSHOT</version>
+	<version>0.10.1-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.7.qualifier
+Bundle-Version: 0.5.8.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.7-SNAPSHOT</version>
+	<version>0.5.8-SNAPSHOT</version>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
This PR change which(node) behavior only for macOS.

On macOS, Bash is not the default shell since macOS 10.15. Now it's /bin/zsh.

Before WWD which(node) implementation used always /bin/bash to find NodeJS path which fails when Bash is not configured.

Now the new code first find the shell for current user and then find NodeJS path. It should always succeed to find NodeJS, as long as user has configured NodeJS in its shell.