### PR TITLE
Register JSON Schema via extension point

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,16 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 The extension point `org.eclipse.wildwebdeveloper.xml` now allows a new `initializationOptionsProvider` child element type, which can be used to specify some initialize options. This is typically useful for language server who should be configured according some some user preferences already configured somewhere else in the IDE, so such preferences can be propageted to the language server.
 
+#### Extension point to define JSON Schema URLs
+
+The extension point `org.eclipse.wildwebdeveloper.json.schema` allows record JSON schema for filename pattern. This records are registered in JSON Language Server during initialization:
+
+```xml
+<extension point="org.eclipse.wildwebdeveloper.json.schema">
+      <schema pattern="composer.json" url="http://json.schemastore.org/composer" />
+</extension>
+```
+
 ## 0.9.1
 
 * 📅 Release Date: May 4th 2020

--- a/org.eclipse.wildwebdeveloper.tests/pom.xml
+++ b/org.eclipse.wildwebdeveloper.tests/pom.xml
@@ -31,6 +31,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<argLine>${tycho.testArgLine} ${ui.test.vmargs}</argLine>
 					<useUIThread>true</useUIThread>
 					<useUIHarness>true</useUIHarness>
 				</configuration>

--- a/org.eclipse.wildwebdeveloper/build.properties
+++ b/org.eclipse.wildwebdeveloper/build.properties
@@ -8,6 +8,7 @@ bin.includes = META-INF/,\
                language-configurations/,\
                grammars/,\
                snippets/,\
-               icons/
+               icons/,\
+               schema/
 # See https://github.com/redhat-developer/yaml-language-server/issues/253
 bin.excludes = node_modules/yaml-language-server/out/server/node_modules/

--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension-point id="org.eclipse.wildwebdeveloper.json.schema" name="Bind JSON Schema to filename pattern" schema="schema/json.schema.exsd"/>
 
    <!-- Wild Web Developer/Core -->
    <extension

--- a/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
+++ b/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
@@ -18,7 +18,7 @@
       </annotation>
       <complexType>
          <sequence minOccurs="1" maxOccurs="unbounded">
-            <element ref="file"/>
+            <element ref="schema"/>
          </sequence>
          <attribute name="point" type="string" use="required">
             <annotation>
@@ -47,21 +47,6 @@
       </complexType>
    </element>
 
-   <element name="file">
-      <complexType>
-         <sequence minOccurs="1" maxOccurs="unbounded">
-            <element ref="schema"/>
-         </sequence>
-         <attribute name="name" type="string" use="required">
-            <annotation>
-               <documentation>
-                  File name pattern
-               </documentation>
-            </annotation>
-         </attribute>
-      </complexType>
-   </element>
-
    <element name="schema">
       <annotation>
          <documentation>
@@ -69,6 +54,13 @@
          </documentation>
       </annotation>
       <complexType>
+         <attribute name="pattern" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -77,7 +69,7 @@
          <meta.section type="since"/>
       </appinfo>
       <documentation>
-         [Enter the first release in which this extension point appears.]
+         0.5.8
       </documentation>
    </annotation>
 
@@ -86,27 +78,30 @@
          <meta.section type="examples"/>
       </appinfo>
       <documentation>
-         [Enter extension point usage example here.]
+         &lt;p&gt;Root project file&lt;/p&gt;
+&lt;pre&gt;
+&amp;lt;schema pattern=&amp;quot;/.eslintrc&amp;quot;http://json.schemastore.org/eslintrc&amp;lt;/schema&amp;gt;
+&lt;/pre&gt;
+
+&lt;p&gt;Wildcard name&lt;/p&gt;
+&lt;pre&gt;
+&amp;lt;schema pattern=&amp;quot;tsconfig.*.json&amp;quot;http://json.schemastore.org/tsconfig&amp;lt;/schema&amp;gt;
+&lt;/pre&gt;
       </documentation>
    </annotation>
+
+
 
    <annotation>
       <appinfo>
-         <meta.section type="apiinfo"/>
+         <meta.section type="copyright"/>
       </appinfo>
       <documentation>
-         [Enter API information here.]
+         Copyright (c) 2020 Dawid Pakuła and others.&lt;br&gt;
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is available at &lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0/&quot;&gt;https://www.eclipse.org/legal/epl-2.0/&lt;/a&gt;
+
+SPDX-License-Identifier: EPL-2.0
       </documentation>
    </annotation>
-
-   <annotation>
-      <appinfo>
-         <meta.section type="implementation"/>
-      </appinfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
-
 
 </schema>

--- a/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
+++ b/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.wildwebdeveloper" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.wildwebdeveloper" id="org.eclipse.wildwebdeveloper.json.schema" name="Bind JSON Schema to filename pattern"/>
+      </appinfo>
+      <documentation>
+         Register JSON schema
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="file"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="file">
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="schema"/>
+         </sequence>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  File name pattern
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="schema">
+      <annotation>
+         <documentation>
+            URL as value
+         </documentation>
+      </annotation>
+      <complexType>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
+++ b/org.eclipse.wildwebdeveloper/schema/json.schema.exsd
@@ -50,14 +50,25 @@
    <element name="schema">
       <annotation>
          <documentation>
-            URL as value
+            Schema entry
          </documentation>
       </annotation>
       <complexType>
          <attribute name="pattern" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  &lt;ul&gt;
+&lt;li&gt;tsconfig.json - directory doesn&apos;t matter&lt;/li&gt;
+&lt;li&gt;/tsconfig.json - only in root directory&lt;/li&gt;
+&lt;li&gt;tsconfig.*.json - wildcard name&lt;/li&gt;
+&lt;/ul&gt;
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="url" type="string" use="required">
+            <annotation>
+               <documentation>
+                  URL to schema, for example: http://json.schemastore.org/tsconfig
                </documentation>
             </annotation>
          </attribute>
@@ -80,12 +91,12 @@
       <documentation>
          &lt;p&gt;Root project file&lt;/p&gt;
 &lt;pre&gt;
-&amp;lt;schema pattern=&amp;quot;/.eslintrc&amp;quot;http://json.schemastore.org/eslintrc&amp;lt;/schema&amp;gt;
+&amp;lt;schema pattern=&amp;quot;/.eslintrc&amp;quot; url=&amp;quot;http://json.schemastore.org/eslintrc&amp;quot; /&amp;gt;
 &lt;/pre&gt;
 
 &lt;p&gt;Wildcard name&lt;/p&gt;
 &lt;pre&gt;
-&amp;lt;schema pattern=&amp;quot;tsconfig.*.json&amp;quot;http://json.schemastore.org/tsconfig&amp;lt;/schema&amp;gt;
+&amp;lt;schema pattern=&amp;quot;tsconfig.*.json&amp;quot; url=&amp;quot;http://json.schemastore.org/tsconfig&amp;quot; /&amp;gt;
 &lt;/pre&gt;
       </documentation>
    </annotation>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/json/JSonLanguageServer.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/json/JSonLanguageServer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *  Michal� Niewrzal� (Rogue Wave Software Inc.) - initial implementation
+ *  Michał Niewrzal (Rogue Wave Software Inc.) - initial implementation
  *  Angelo Zerr <angelo.zerr@gmail.com> - JSON Schema support
  *  Dawid Pakuła <zulus@w3des.net> - JSON Schema extension point
  *******************************************************************************/
@@ -40,8 +40,7 @@ import org.eclipse.wildwebdeveloper.InitializeLaunchConfigurations;
 public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 
 	private final static String SCHEMA_EXT = "org.eclipse.wildwebdeveloper.json.schema"; //$NON-NLS-1$
-	private final static String NAME_ATTR = "name"; //$NON-NLS-1$
-	private final static String SCHEMA_ELEMENT = "schema"; //$NON-NLS-1$
+	private final static String PATTERN_ATTR = "pattern"; //$NON-NLS-1$
 	public JSonLanguageServer() {
 		List<String> commands = new ArrayList<>();
 		commands.add(InitializeLaunchConfigurations.getNodeJsLocation());
@@ -119,17 +118,15 @@ public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 	private void fillSchemaAssociationsFromExtensionPoint(Map<String, List<String>> associations) {
 		IConfigurationElement[] conf = Platform.getExtensionRegistry().getConfigurationElementsFor(SCHEMA_EXT);
 		for (IConfigurationElement el : conf) {
-			associations.put(el.getAttribute(NAME_ATTR), collectSchemaURL(el.getChildren(SCHEMA_ELEMENT)));
+			String pattern = el.getAttribute(PATTERN_ATTR);
+			if (!associations.containsKey(pattern)) {
+				associations.put(pattern, new ArrayList<>());
+			}
+			associations.get(pattern).add(el.getValue());
 		}
 	}
 
-	private List<String> collectSchemaURL(IConfigurationElement[] schema) {
-		List<String> list = new ArrayList<>(schema.length);
-		for (IConfigurationElement el : schema) {
-			list.add(el.getValue());
-		}
-		return list;
-	}
+	
 
 	@Override
 	public Object getInitializationOptions(URI rootUri) {

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/json/JSonLanguageServer.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/json/JSonLanguageServer.java
@@ -41,6 +41,7 @@ public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 
 	private final static String SCHEMA_EXT = "org.eclipse.wildwebdeveloper.json.schema"; //$NON-NLS-1$
 	private final static String PATTERN_ATTR = "pattern"; //$NON-NLS-1$
+	private final static String URL_ATTR = "url"; //$NON-NLS-1$
 	public JSonLanguageServer() {
 		List<String> commands = new ArrayList<>();
 		commands.add(InitializeLaunchConfigurations.getNodeJsLocation());
@@ -122,7 +123,7 @@ public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 			if (!associations.containsKey(pattern)) {
 				associations.put(pattern, new ArrayList<>());
 			}
-			associations.get(pattern).add(el.getValue());
+			associations.get(pattern).add(el.getAttribute(URL_ATTR));
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<tycho-version>1.7.0</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/wildwebdeveloper.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<ui.test.vmargs />
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Simple implementation of eclipse/wildwebdeveloper#429.

Example usage:

```xml
<extension point="org.eclipse.wildwebdeveloper.json.schema">
      <schema pattern="composer.json" url="http://json.schemastore.org/composer" />
      <schema pattern="/tsconfig.*.json" url="http://json.schemastore.org/tsconfig" />
</extension>
```

Note: patch also contain macOS test fix