### PR TITLE
Account pom.xml change in qualifier computation

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for WildWebDeveloper
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.tests
-Bundle-Version: 0.4.4.qualifier
+Bundle-Version: 0.4.5.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.wildwebdeveloper.tests/pom.xml
+++ b/org.eclipse.wildwebdeveloper.tests/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.4.4-SNAPSHOT</version>
+	<version>0.4.5-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -18,6 +18,9 @@
 					<filesets>
 						<fileset>
 							<directory>node_modules</directory>
+							<includes>
+								<include>package-lock.json</include>
+							</includes>
 						</fileset>
 					</filesets>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
 					</dependencies>
 					<configuration>
 						<timestampProvider>jgit</timestampProvider>
-						<jgit.ignore>pom.xml</jgit.ignore>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
As most embedded deps are configured in pom.xml and the pom files don't
change much otherwise, let's take the pom.xml into account for qualifier
computation so important changes lead to new version (preventing from
further baseline replacement).
Also remove package-lock.json on clean.

Signed-off-by: Mickael Istria <mistria@redhat.com>