### PR TITLE
Update language servers

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestLanguageServers.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestLanguageServers.java
@@ -221,6 +221,7 @@ public class TestLanguageServers {
 		final int MAX_ALLOWED_RELATIVE_PATH = 140; // that leaves 120 characters for the path to the bundle
 //C:/Users/Jean-Jacques Saint-Romain/developpement/eclipse/plugins/org.eclipse.wildwebdeveloper_1.2.3.20201212_1605/
 		String location = Platform.getBundle("org.eclipse.wildwebdeveloper").getLocation();
+
 		if (location.startsWith("initial@")) {
 			location = location.substring("initial@".length());
 		}
@@ -230,6 +231,8 @@ public class TestLanguageServers {
 		if (location.startsWith("file:")) {
 			location = location.substring("file:".length());
 		}
+		System.out.println("Location (" + location.length() + "): " + location);
+		StringBuilder maxLocation = new StringBuilder();
 		File file = new File(new File(Platform.getInstallLocation().getURL().toURI()), location);
 		assertTrue(file.isDirectory());
 		Map<String, Integer> tooLongPaths = new TreeMap<>();
@@ -240,7 +243,12 @@ public class TestLanguageServers {
 				String relativePathInsideBundle = pluginPath.relativize(dir).toString();
 				if (relativePathInsideBundle.startsWith("target")) {
 					return FileVisitResult.SKIP_SUBTREE;
-				} else if (relativePathInsideBundle.length() > MAX_ALLOWED_RELATIVE_PATH) {
+				}
+				if (maxLocation.length() < relativePathInsideBundle.length()) {
+					maxLocation.setLength(0);
+					maxLocation.append(relativePathInsideBundle);
+				}
+				if (relativePathInsideBundle.length() > MAX_ALLOWED_RELATIVE_PATH) {
 					tooLongPaths.put(relativePathInsideBundle, relativePathInsideBundle.length());
 					return FileVisitResult.SKIP_SUBTREE;
 				}
@@ -256,6 +264,7 @@ public class TestLanguageServers {
 				return FileVisitResult.CONTINUE;
 			}
 		});
+		System.out.println("Max Location found (" + maxLocation.length() + "): " + maxLocation.toString());
 		assertEquals(Collections.emptyMap(), tooLongPaths);
 	}
 }

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -117,19 +117,19 @@
 								<arg>typescript@3.9.7</arg>
 								<arg>typescript-language-server@0.4.0</arg>
 								<arg>typescript-lit-html-plugin@0.9.0</arg>
-								<arg>typescript-plugin-css-modules@2.4.0</arg>
+								<arg>typescript-plugin-css-modules@2.8.0</arg>
 								<arg>${project.build.directory}/vscode-css-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-html-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-json-languageserver-1.2.3.tgz</arg>
-								<arg>yaml-language-server@0.11.0</arg>
-								<arg>firefox-debugadapter@2.9.0</arg>
+								<arg>yaml-language-server@0.12.0</arg>
+								<arg>firefox-debugadapter@2.9.1</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.12.8.tgz</arg>
-								<arg>typescript-eslint-language-service@3.0.0</arg>
+								<arg>typescript-eslint-language-service@3.1.0</arg>
 								<arg>eslint@7.5.0</arg>
-								<arg>@typescript-eslint/eslint-plugin@3.2.0</arg>
-								<arg>@typescript-eslint/parser@3.2.0</arg>
-								<arg>@angular/language-service@10.0.4</arg>
-								<arg>@angular/language-server@0.1001.0</arg>
+								<arg>@typescript-eslint/eslint-plugin@3.10.1</arg>
+								<arg>@typescript-eslint/parser@3.10.1</arg>
+								<arg>@angular/language-service@10.2.2</arg>
+								<arg>@angular/language-server@0.1001.1</arg>
 							</arguments>
 							<workingDirectory>${project.basedir}</workingDirectory>
 						</configuration>


### PR DESCRIPTION
The following LS modules will be updated:

typescript-plugin-css-modules@2.8.0
yaml-language-server@0.12.0</arg>
firefox-debugadapter@2.9.1</arg>
typescript-eslint-language-service@3.1.0</arg>
@typescript-eslint/eslint-plugin@3.10.1</arg>
@typescript-eslint/parser@3.10.1</arg>
@angular/language-service@10.2.2</arg>
@angular/language-server@0.1001.1</arg>

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>