### PR TITLE
Fixes for the ESLint vscode intergration

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
@@ -9,6 +9,9 @@
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper.eslint;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -16,8 +19,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4e.LanguageClientImpl;
+import org.eclipse.lsp4j.ConfigurationItem;
 import org.eclipse.lsp4j.ConfigurationParams;
-import org.eclipse.wildwebdeveloper.embedder.node.NodeJSManager;
 
 public class ESLintClientImpl extends LanguageClientImpl implements ESLintLanguageServerExtension {
 
@@ -28,10 +31,42 @@ public class ESLintClientImpl extends LanguageClientImpl implements ESLintLangua
 
 	@Override
 	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
-		Map<String, String> config = new HashMap<>(3, 1.f);
+		ConfigurationItem configurationItem = configurationParams.getItems().get(0);
+		
+		Map<String, Object> config = new HashMap<>(6, 1.f);
+
+		// search first for the highest directory that has a package.json file
+		// to be set as the workspaceFolder below
+		// then when the workingDirectory is set in mode:auto the eslint server code will look up
+		// until the workspaceFolder which folder is best suited for its workingDirectoy (where the config files are in)
+		// also this workspaceDirectory is also used to find the node models (eslint module)
+		// because we set the nodePath below to "" 
+		File highestPackageJsonDir = null;
+		try {
+			highestPackageJsonDir = new File(new URI(configurationItem.getScopeUri())).getParentFile();;
+			File parentFile = highestPackageJsonDir;
+			while (parentFile != null) {
+				if (new File(parentFile, "package.json").exists()) highestPackageJsonDir = parentFile;
+				parentFile = parentFile.getParentFile();
+			}
+		} catch (URISyntaxException e) {
+			// shouldn't happen else what to do here?
+		}
+		config.put("workspaceFolder", Collections.singletonMap("uri", highestPackageJsonDir.toURI().toString())); 
+
+		// if you set a workspaceFolder and then the working dir in auto mode it will try to go to the right node_modules folder
+		config.put("workingDirectory", Collections.singletonMap("mode", "auto")); 
+
+
+		// this should not point to a nodejs executable but nodePath is the path to the "node_modules" 
+		// (or a parent having node modules, we just push in the highest dir that has the package.json)
+		config.put("nodePath", highestPackageJsonDir.getAbsolutePath());
+		
 		config.put("validate", "on");
 		config.put("run", "onType");
-		config.put("nodePath", NodeJSManager.getNodeJsLocation().getAbsolutePath());
+
+		config.put("codeAction", Map.of("disableRuleComment", Map.of("enable", "true", "location", "separateLine"), 
+										"showDocumentation", Collections.singletonMap("enable", "true")));
 		return CompletableFuture.completedFuture(Collections.singletonList(config));
 	}
 

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/eslint/ESLintClientImpl.java
@@ -39,8 +39,8 @@ public class ESLintClientImpl extends LanguageClientImpl implements ESLintLangua
 		// to be set as the workspaceFolder below
 		// then when the workingDirectory is set in mode:auto the eslint server code will look up
 		// until the workspaceFolder which folder is best suited for its workingDirectoy (where the config files are in)
-		// also this workspaceDirectory is also used to find the node models (eslint module)
-		// because we set the nodePath below to "" 
+		// also this workspaceFolder is also used to find the node models (eslint module)
+		// because we set the nodePath below to this same directory.
 		File highestPackageJsonDir = null;
 		try {
 			highestPackageJsonDir = new File(new URI(configurationItem.getScopeUri())).getParentFile();;
@@ -54,12 +54,12 @@ public class ESLintClientImpl extends LanguageClientImpl implements ESLintLangua
 		}
 		config.put("workspaceFolder", Collections.singletonMap("uri", highestPackageJsonDir.toURI().toString())); 
 
-		// if you set a workspaceFolder and then the working dir in auto mode it will try to go to the right node_modules folder
+		// if you set a workspaceFolder and then the working dir in auto mode eslint will try to get to the right config location.
 		config.put("workingDirectory", Collections.singletonMap("mode", "auto")); 
 
 
 		// this should not point to a nodejs executable but nodePath is the path to the "node_modules" 
-		// (or a parent having node modules, we just push in the highest dir that has the package.json)
+		// (or a parent having node modules, we just push in the highest dir (workspaceFolder) that has the package.json)
 		config.put("nodePath", highestPackageJsonDir.getAbsolutePath());
 		
 		config.put("validate", "on");


### PR DESCRIPTION
set the right nodePath (should be a (parent) dir that has the
node_modules that has again eslint)
set the workingFolder (for now the highest folder with a package.json)
and set the workingDirectory property in auto mode so eslint server will
try to find the best location of the eslint config file for the given
file.