### PR TITLE
Chrome Debug Fails to Start #588

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ spec:
 			steps {
 				container('container') {
 					wrap([$class: 'Xvnc', useXauthority: true]) {
-						sh 'mvn clean verify -B -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+						sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
 					}
 				}
 			}

--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.10.5.qualifier"
+      version="0.10.6.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.10.5-SNAPSHOT</version>
+	<version>0.10.6-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.13.qualifier
+Bundle-Version: 0.5.14.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.13-SNAPSHOT</version>
+	<version>0.5.14-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/Activator.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/Activator.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wildwebdeveloper;
 
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -53,4 +56,23 @@ public class Activator extends AbstractUIPlugin {
 		return plugin;
 	}
 
+	/**
+	 * Returns the currently active workbench window shell or <code>null</code>
+	 * if none.
+	 *
+	 * @return the currently active workbench window shell or <code>null</code>
+	 */
+	public static Shell getShell() {
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (window == null) {
+			IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+			if (windows.length > 0) {
+				return windows[0].getShell();
+			}
+		}
+		else {
+			return window.getShell();
+		}
+		return null;
+	}
 }

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/MessageUtils.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/MessageUtils.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.debug;
+
+import java.text.MessageFormat;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationEditDialog;
+import org.eclipse.debug.internal.ui.launchConfigurations.LaunchGroupExtension;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.ILaunchGroup;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.preference.IPreferenceNode;
+import org.eclipse.jface.preference.PreferenceDialog;
+import org.eclipse.jface.preference.PreferenceManager;
+import org.eclipse.jface.preference.PreferenceNode;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.browser.WebBrowserPreferencePage;
+import org.eclipse.wildwebdeveloper.Activator;
+
+@SuppressWarnings("restriction")
+public class MessageUtils {
+	private static final String BROWSER_TAB_NAME = "Browser"; //$NON-NLS-1$
+	private static final String WEB_BROWSER_PREFERENCE_PAGE = "org.eclipse.ui.browser.preferencePage"; //$NON-NLS-1$
+	
+	private MessageUtils() {
+		// stateless, don't instantiate
+	}
+	
+	/**
+	 * Shows an error message, suggesting to fix browser location either by
+	 * - Selecting a Runtime executable in launch configuration (if applicable)
+	 * - Adding/editing a browser in Web Browser preference page
+	 * 
+	 * @param parentShell  the parent shell of the dialog, or <code>null</code> if none
+	 * @param configuration A launch configuration
+	 * @param mode a launch mode 
+	 * @param browserName a browser display name 
+	 * @param suggestEditLaunch <code>true</code> in case of opening a launch configuration Browser tab is to be suggested, otherwise - <code>false</code>
+	 * @return the <code>int</code> status of opening the dialog
+	 */
+	public static int showBrowserLocationsConfigurationError(Shell parentShell, ILaunchConfiguration configuration, String mode, String browserName, boolean suggestEditLaunch) {
+		String title = MessageFormat.format(Messages.RuntimeExecutable_NotDefinedError_Title, browserName);
+		String browserTabMessage = suggestEditLaunch ? MessageFormat.format(Messages.RuntimeExecutable_NotDefinedError_Message_1, browserName) : ""; //$NON-NLS-1$
+		String webBrowsersMessage = MessageFormat.format(Messages.RuntimeExecutable_NotDefinedError_Message_2, browserName);
+		String message = MessageFormat.format(Messages.RuntimeExecutable_NotDefinedError_Message, browserName, browserTabMessage, webBrowsersMessage);
+		IStatus errorStatus = new Status(IStatus.ERROR, Activator.PLUGIN_ID, title);
+		Activator.getDefault().getLog().log(errorStatus);
+
+		int result[] = {Window.CANCEL};
+		Display.getDefault().syncExec(() -> {
+			int response = suggestEditLaunch ?
+					MessageDialog.open(MessageDialog.ERROR, parentShell, title, message, SWT.NONE, 
+							Messages.RuntimeExecutable_NotDefinedError_OpenLaunchConfigurationBrowserTab,
+							Messages.RuntimeExecutable_NotDefinedError_OpenWebBrowserPreferencePage,
+							IDialogConstants.CANCEL_LABEL) :
+						MessageDialog.open(MessageDialog.ERROR, parentShell, title, message, SWT.NONE, 
+									Messages.RuntimeExecutable_NotDefinedError_OpenWebBrowserPreferencePage,
+									IDialogConstants.CANCEL_LABEL);
+			if (!suggestEditLaunch) {
+				response++;
+			}
+			if (response == 0) {
+				ILaunchGroup group = DebugUITools.getLaunchGroup(configuration, mode);
+				if (group != null) {
+					LaunchGroupExtension groupExt = DebugUIPlugin.getDefault().getLaunchConfigurationManager().getLaunchGroup(group.getIdentifier());
+					if (groupExt != null) {
+						final LaunchConfigurationEditDialog dialog = new LaunchConfigurationEditDialog(parentShell, configuration, groupExt, false);
+						BusyIndicator.showWhile(PlatformUI.getWorkbench().getDisplay(), () -> {
+							dialog.create();
+
+							ILaunchConfigurationTab[] tabs = dialog.getTabs();
+							if(tabs != null) {
+								for (int i = 0; i < tabs.length; i++) {
+									if (tabs[i].getName().equals(BROWSER_TAB_NAME)) {
+										dialog.setActiveTab(i);
+										break;
+									}
+								}
+							}
+							result[0] = dialog.open();
+						});
+					}
+				}
+			} else if (response == 1) {
+				WebBrowserPreferencePage page = new WebBrowserPreferencePage();
+				page.setTitle(org.eclipse.ui.internal.browser.Messages.preferenceWebBrowserTitle);
+				final IPreferenceNode targetNode = new PreferenceNode(WEB_BROWSER_PREFERENCE_PAGE, page);
+				PreferenceManager manager = new PreferenceManager();
+				manager.addToRoot(targetNode);
+				final PreferenceDialog dialog = new PreferenceDialog(parentShell, manager);
+				BusyIndicator.showWhile(PlatformUI.getWorkbench().getDisplay(), () -> {
+					dialog.create();
+					dialog.setMessage(targetNode.getLabelText());
+					result[0] = dialog.open();
+				});
+			}
+		});
+		return result[0];
+	}
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/Messages.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/Messages.java
@@ -50,6 +50,15 @@ public class Messages extends NLS {
 	public static String NodeDebug_TSConfirError_StartDebuggingAsIs;
 	public static String NodeDebug_TSConfirError_Cancel;
 	
+	public static String RuntimeExecutable_NotDefinedError_Title;
+	public static String RuntimeExecutable_NotDefinedError_Message;
+	public static String RuntimeExecutable_NotDefinedError_Message_1;
+	public static String RuntimeExecutable_NotDefinedError_Message_2;
+	public static String RuntimeExecutable_NotDefinedError_OpenWebBrowserPreferencePage;
+	public static String RuntimeExecutable_NotDefinedError_OpenLaunchConfigurationBrowserTab;
+	public static String RuntimeExecutable_Chrome;
+	public static String RuntimeExecutable_Firefox;
+	
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/messages.properties
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/messages.properties
@@ -45,3 +45,12 @@ NodeDebug_TSConfirError_OpenTSConfigInEditor=Edit "tsconfig.json"
 NodeDebug_TSConfirError_CreateAndOpenTSConfigInEditor=Create "tsconfig.json"
 NodeDebug_TSConfirError_StartDebuggingAsIs=Start Debugging as is
 NodeDebug_TSConfirError_Cancel=Cancel
+
+RuntimeExecutable_NotDefinedError_Title=Couldn''t find {0} browser location
+RuntimeExecutable_NotDefinedError_Message=No Browser executable defined for {0}. Please ensure that:\n{1}{2}
+RuntimeExecutable_NotDefinedError_Message_1=\n- {0} browser is selected in launch configuration Browser tab.
+RuntimeExecutable_NotDefinedError_Message_2=\n- Location of {0} browser is properly specified in Web Browser preference page or add it in case it's not defined yet.
+RuntimeExecutable_NotDefinedError_OpenWebBrowserPreferencePage=Open Web Browser Preferences
+RuntimeExecutable_NotDefinedError_OpenLaunchConfigurationBrowserTab=Edit Launch Configuration
+RuntimeExecutable_Chrome=Chrome
+RuntimeExecutable_Firefox=Firefox


### PR DESCRIPTION
When Chrome/Firefox Debug launch is created, the only browser defined in 'Run with:` field of launch configuration is to be used to start debuging. So, no any additional searches for a browser executable to be performed.
If no browser is confiured, a message is displayed prompting a user to open Launch Configuration Browser Tab or Web Browser preference page to configure/select a correct browser.
    
Firefox Debug is also updated to serach fora browser executable in a list of browsers defined in Web Browser preference page.
If no executable can be found it is suggested to open Web Browser preference page to add/edit Firefox browser location.

Fixes: #588
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>