### PR TITLE
Update to Fedora 33 docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipsecbi/fedora-gtk3-mutter:31-gtk3.24
+FROM eclipsecbi/fedora-gtk3-mutter:33-gtk3.24
 
 # Back to root for install
 USER 0


### PR DESCRIPTION
This means Node.js switches from 12 to 14 and we would better run our
tests with latest LTS version.


Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>