### PR TITLE
upgraded esLint server (vscode) to version 2.1.14

### DIFF
--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -61,8 +61,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<!-- Using 2.1.1 for now because if a bug in diagnostic, that's alrady fixed in master, for 2.1.14 -->
-							<url>https://marketplace.visualstudio.com/_apis/public/gallery/publishers/dbaeumer/vsextensions/vscode-eslint/2.1.1/vspackage</url>
+							<url>https://marketplace.visualstudio.com/_apis/public/gallery/publishers/dbaeumer/vsextensions/vscode-eslint/2.1.14/vspackage</url>
 							<outputFileName>vscode-eslint-ls.zip</outputFileName>
 							<unpack>true</unpack>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls</outputDirectory>
@@ -75,7 +74,8 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://raw.githubusercontent.com/microsoft/vscode-eslint/release/2.1.13/server/package.json</url>
+							<skipCache>true</skipCache>
+							<url>https://raw.githubusercontent.com/microsoft/vscode-eslint/release/2.1.14/server/package.json</url>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls/extension/server</outputDirectory>
 						</configuration>
 					</execution>
@@ -151,7 +151,7 @@
 								<arg>yaml-language-server@0.14.0</arg>
 								<arg>firefox-debugadapter@2.9.1</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.12.11.tgz</arg>
-								<arg>${project.build.directory}/eslint-server-2.1.10.tgz</arg>
+								<arg>${project.build.directory}/eslint-server-2.1.14.tgz</arg>
 								<arg>@angular/language-server@11.1.1</arg>
 							</arguments>
 							<workingDirectory>${project.basedir}</workingDirectory>


### PR DESCRIPTION
update to the latest esLint server of vscode, the previous problem of 2.1.13 seems to be fixed in this .14 release