### PR TITLE
implemented a LanguageClientImpl for angular

### DIFF
--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.10.6.qualifier"
+      version="0.10.7.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.10.6-SNAPSHOT</version>
+	<version>0.10.7-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.14.qualifier
+Bundle-Version: 0.5.15.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.14-SNAPSHOT</version>
+	<version>0.5.15-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularClientImpl.java
@@ -1,0 +1,53 @@
+package org.eclipse.wildwebdeveloper.angular;
+
+import java.util.Map;
+
+import org.eclipse.lsp4e.LanguageClientImpl;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.WorkDoneProgressNotification;
+import org.eclipse.lsp4j.WorkDoneProgressReport;
+
+public class AngularClientImpl extends LanguageClientImpl implements AngularLanguageServerExtention {
+
+	@Override
+	public void projectLoadingFinish(Object object) {
+		// TODO should this set some state because only now stuff will work like hover..
+		// or maybe even after projectLanguageService "enabled" call
+		logMessage(new MessageParams(MessageType.Info, "Angular project loading finished"));
+	}
+	
+	@Override
+	public void projectLoadingStart(Object object) {
+		logMessage(new MessageParams(MessageType.Info, "Angular project loading started"));
+	}
+	
+	@Override
+	public void projectLanguageService(Map<String,Object> data) {
+		logMessage(new MessageParams(MessageType.Info, "Language Service is " + (((Boolean)data.get("languageServiceEnabled")).booleanValue()?"":"not yet ") + "enabled for project " + data.get("projectName")));
+	}
+
+	@Override
+	public void suggestIvyLanguageServiceMode(Object o) {
+		logMessage(new MessageParams(MessageType.Info, o.toString()));
+		// TODO should this propose a setting (in the preferences) that enables --experimental-ivy command in the AngularLanguageServer)
+	}
+
+	@Override
+	public void suggestStrictMode(Object o) {
+		// this only says to the developer that they should enabled something in there tsconfig file (strictTemplates: true)
+		// can't do any from there (like  suggestIvyLanguageServiceMode has to do)
+		logMessage(new MessageParams(MessageType.Info, o.toString()));
+	}
+	
+	@Override
+	public void notifyProgress(ProgressParams params) {
+		String message = null;
+		WorkDoneProgressNotification value = params.getValue();
+		if (value instanceof WorkDoneProgressReport) {
+			message = ((WorkDoneProgressReport) value).getMessage();
+		}
+		logMessage(new MessageParams(MessageType.Info, params.getToken().getLeft()  + ": " + (message == null? "done":message)));
+	}
+}

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularLanguageServerExtention.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularLanguageServerExtention.java
@@ -1,0 +1,23 @@
+package org.eclipse.wildwebdeveloper.angular;
+
+import java.util.Map;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+
+public interface AngularLanguageServerExtention {
+
+	@JsonNotification(value = "angular/projectLoadingStart")
+	public void projectLoadingStart(Object object);
+	
+	@JsonNotification(value = "angular/projectLoadingFinish")
+	public void projectLoadingFinish(Object object);
+	
+	@JsonNotification(value = "angular/projectLanguageService")
+	public void projectLanguageService(Map<String,Object> data);
+
+	@JsonNotification(value = "angular/suggestStrictMode")
+	public void suggestStrictMode(Object o);
+
+	@JsonNotification(value = "angular/suggestIvyLanguageServiceMode")
+	public void suggestIvyLanguageServiceMode(Object o);
+}

--- a/repository/epp.product
+++ b/repository/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for JavaScript and Web Developers" uid="org.eclipse.wildwebdeveloper.product" id="org.eclipse.wildwebdeveloper.product.branding.product" application="org.eclipse.ui.ide.workbench" version="0.11.5.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for JavaScript and Web Developers" uid="org.eclipse.wildwebdeveloper.product" id="org.eclipse.wildwebdeveloper.product.branding.product" application="org.eclipse.ui.ide.workbench" version="0.11.6.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.wildwebdeveloper.product.branding.product/eclipse_lg.png"/>


### PR DESCRIPTION
added json request/notifications for:
projectLoadingStart, projectLoadingFinish, projectLanguageService,
suggestIvyLanguageServiceMode, suggestStrictMode and implemented
notifyProgress

For now these all just log, but suggestIvyLanguageServiceMode should
give the user an option (or point to an option) to enable the
commands.add("--experimental-ivy");
in the AngularLanguageServer

(this should i think be a setting in the preferences)
Problem is a bit if you enabled this now that you get many exception in
the log because of: https://github.com/eclipse/lsp4j/issues/479

Signed-off-by: Johan Compagner <jcompagner@gmail.com>