### PR TITLE
Update Language Servers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ kind: Pod
 spec:
   containers:
   - name: container
-    image: docker.io/mickaelistria/fedora-gtk3-mutter-java-node:33
+    image: docker.io/mickaelistria/fedora-gtk3-mutter-java-node:34
     imagePullPolicy: Always
     tty: true
     command: [ "uid_entrypoint", "cat" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipsecbi/fedora-gtk3-mutter:33-gtk3.24
+FROM eclipsecbi/fedora-gtk3-mutter:34-gtk3.24
 
 # Back to root for install
 USER 0
@@ -6,8 +6,11 @@ RUN dnf -y update && dnf -y install \
 	java-11-openjdk-devel maven
 RUN dnf -y update && dnf -y install \
 	nodejs npm
-	
-ENV PATH=/usr/lib/jvm/java-11/bin:$PATH
+RUN dnf -y install xz
+
+RUN curl -L https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz | tar -xJ
+
+ENV PATH=/node-v16.13.0-linux-x64/bin:/usr/lib/jvm/java-11/bin:$PATH
 ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 #Back to named user

--- a/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for WildWebDeveloper
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.tests;singleton:=true
-Bundle-Version: 0.4.13.qualifier
+Bundle-Version: 0.4.14.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.wildwebdeveloper;bundle-version="0.5.3",
+Require-Bundle: org.eclipse.wildwebdeveloper;bundle-version="0.5.18",
  org.junit.jupiter.api;bundle-version="5.6.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/org.eclipse.wildwebdeveloper.tests/build.properties
+++ b/org.eclipse.wildwebdeveloper.tests/build.properties
@@ -1,7 +1,7 @@
-source.. = src/,\
-           resources/
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                testProjects/,\
+               resources/,\
                .,\
                plugin.xml

--- a/org.eclipse.wildwebdeveloper.tests/plugin.xml
+++ b/org.eclipse.wildwebdeveloper.tests/plugin.xml
@@ -9,7 +9,7 @@
       </schema>
       <schema
             pattern="depp.yml"
-            url="platform:/plugin/org.eclipse.wildwebdeveloper.tests/dependabot.json">
+            url="platform:/plugin/org.eclipse.wildwebdeveloper.tests/resources/dependabot.json">
       </schema>
    </extension>
 </plugin>

--- a/org.eclipse.wildwebdeveloper.tests/pom.xml
+++ b/org.eclipse.wildwebdeveloper.tests/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.4.13-SNAPSHOT</version>
+	<version>0.4.14-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestAngular.java
@@ -61,7 +61,7 @@ public class TestAngular {
 							.stream(appComponentFile.findMarkers("org.eclipse.lsp4e.diagnostic", true,
 									IResource.DEPTH_ZERO))
 							.anyMatch(marker -> marker.getAttribute(IMarker.LINE_NUMBER, -1) == 5
-									&& marker.getAttribute(IMarker.MESSAGE, "").contains("template"));
+									&& marker.getAttribute(IMarker.MESSAGE, "").contains("not exist"));
 				} catch (CoreException e) {
 					e.printStackTrace();
 					return false;
@@ -90,7 +90,7 @@ public class TestAngular {
 				try {
 					markers = appComponentHTML.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO);
 					return Arrays.stream(markers)
-							.anyMatch(marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("template"));
+							.anyMatch(marker -> marker.getAttribute(IMarker.MESSAGE, "").contains("not exist"));
 				} catch (CoreException e) {
 					return false;
 				}

--- a/org.eclipse.wildwebdeveloper/.gitignore
+++ b/org.eclipse.wildwebdeveloper/.gitignore
@@ -2,4 +2,5 @@ target/
 bin/
 language-servers/
 node_modules/
+package.json
 package-lock.json

--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -485,6 +485,7 @@
          point="org.eclipse.lsp4e.languageServer">
       <server
             class="org.eclipse.wildwebdeveloper.yaml.YAMLLanguageServer"
+            clientImpl="org.eclipse.wildwebdeveloper.yaml.YamlLanguageClientImpl"
             id="org.eclipse.wildwebdeveloper.yaml"
             label="YAML Language Server (VSCode)"
             singleton="true">

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -144,7 +144,7 @@
 								<arg>--no-bin-links</arg>
 								<arg>--ignore-scripts</arg>
 								<arg>${project.build.directory}/node-debug2-1.42.5.tgz</arg>
-								<arg>typescript@4.3.5</arg>
+								<arg>typescript@4.4.4</arg>
 								<arg>typescript-language-server@0.6.4</arg>
 								<arg>typescript-lit-html-plugin@0.9.0</arg>
 								<arg>typescript-plugin-css-modules@3.4.0</arg>
@@ -158,7 +158,7 @@
 										TestYaml.testSchemaExtensionPoint:91->testErrorFile:85 expected: <true> but was: <false>
 										TestYaml.testSchemaExtensionPointUsingPlatformURL:96->testErrorFile:85 expected: <true> but was: <false>
 								-->
-								<arg>yaml-language-server@0.19.2</arg>
+								<arg>yaml-language-server@1.1.0</arg>
 								<arg>firefox-debugadapter@2.9.4</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.12.12.tgz</arg>
 								<arg>${project.build.directory}/eslint-server-2.1.14.tgz</arg>
@@ -168,7 +168,7 @@
 									Failures: 
   										TestAngular.testAngular:56 Diagnostic not published in standalone component file ==> expected: <true> but was: <false>
 								-->
-								<arg>@angular/language-server@11.2.14</arg>
+								<arg>@angular/language-server@12.2.2</arg>
 							</arguments>
 							<workingDirectory>${project.basedir}</workingDirectory>
 						</configuration>

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -155,12 +155,6 @@
 								<arg>firefox-debugadapter@2.9.4</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.12.12.tgz</arg>
 								<arg>${project.build.directory}/eslint-server-2.1.14.tgz</arg>
-								<!-- 
-									A try to update @angular/language-server to any version up to v.12.2.0
-									breaks the receiving of diagnostics: 
-									Failures: 
-  										TestAngular.testAngular:56 Diagnostic not published in standalone component file ==> expected: <true> but was: <false>
-								-->
 								<arg>@angular/language-server@12.2.2</arg>
 							</arguments>
 							<workingDirectory>${project.basedir}</workingDirectory>

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -151,13 +151,6 @@
 								<arg>${project.build.directory}/vscode-css-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-html-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-json-languageserver-1.3.4.tgz</arg>
-								<!-- 
-									A try to update yaml-language-server to any version up to v.0.22.0
-									breaks the validation (error markers aren't set on resources): 
-									Failures: 
-										TestYaml.testSchemaExtensionPoint:91->testErrorFile:85 expected: <true> but was: <false>
-										TestYaml.testSchemaExtensionPointUsingPlatformURL:96->testErrorFile:85 expected: <true> but was: <false>
-								-->
 								<arg>yaml-language-server@1.1.0</arg>
 								<arg>firefox-debugadapter@2.9.4</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.12.12.tgz</arg>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/yaml/YAMLLanguageServer.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/yaml/YAMLLanguageServer.java
@@ -102,12 +102,13 @@ public class YAMLLanguageServer extends ProcessStreamConnectionProvider {
 		}
 	}
 
-	private static Map<String, Object> getYamlConfigurationOptions() {
+	static Map<String, Object> getYamlConfigurationOptions() {
 		Map<String, Object> yaml = new HashMap<>();
 		yaml.put(SCHEMAS_KEY, getSchemaAssociations());
 		yaml.put(VALIDATE_KEY, true);
 		yaml.put(COMPLETION_KEY, true);
 		yaml.put(HOVER_KEY, true);
+		yaml.put("schemaStore.enable", true);
 		return yaml;
 	}
 

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/yaml/YamlLanguageClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/yaml/YamlLanguageClientImpl.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.yaml;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4e.LanguageClientImpl;
+import org.eclipse.lsp4j.ConfigurationParams;
+
+public class YamlLanguageClientImpl extends LanguageClientImpl {
+
+	@Override
+	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+		return CompletableFuture.completedFuture(List.of(YAMLLanguageServer.getYamlConfigurationOptions()));
+	}
+}


### PR DESCRIPTION
Output of Dash License Tool

```
main] INFO Querying Eclipse Foundation for license data for 168 items.
[main] INFO Found 7 items.
[main] INFO Querying ClearlyDefined for license data for 162 items.
[main] INFO Found 162 items.
License information could not be automatically verified for the following content:

npm/npmjs/-/less/4.1.2
npm/npmjs/-/prettier/2.0.5
npm/npmjs/-/sass/1.43.4
npm/npmjs/-/typescript/4.4.4
npm/npmjs/-/vscode-json-languageservice/4.1.9
npm/npmjs/-/yaml-language-server/1.1.0
npm/npmjs/@angular/language-server/12.2.2

This content is either not correctly mapped by the system, or requires review.


Setting up a review for npm/npmjs/-/vscode-json-languageservice/4.1.9.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1522
Setting up a review for npm/npmjs/-/prettier/2.0.5.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1523
Setting up a review for npm/npmjs/-/typescript/4.4.4.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1524
Setting up a review for npm/npmjs/-/yaml-language-server/1.1.0.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1525
Setting up a review for npm/npmjs/-/sass/1.43.4.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1526
Setting up a review for npm/npmjs/-/less/4.1.2.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1527
Setting up a review for npm/npmjs/@angular/language-server/12.2.2.
 - Created: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1528
```