### PR TITLE
Support .cjs and .mjs JavaScript extension variants

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -331,7 +331,7 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.wildwebdeveloper.parent"
-            file-extensions="js"
+            file-extensions="js, cjs, mjs"
             id="org.eclipse.wildwebdeveloper.js"
             name="JavaScript"
             priority="normal">


### PR DESCRIPTION
`.cjs` and `.mjs` are two variants of the standard `.js` JavaScript file extension, which can be used to differentiate between the CommonJS and ESM module systems. More information can be found in the [Node.js documentation](https://nodejs.org/docs/latest/api/packages.html#determining-module-system).