### PR TITLE
Use JS and TS icons for JSX and TSX content types

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -466,7 +466,9 @@
 
    <extension point="org.eclipse.ui.genericeditor.icons">
      <icon contentType="org.eclipse.wildwebdeveloper.js" icon="icons/jsEditorIcon.png"/>
+     <icon contentType="org.eclipse.wildwebdeveloper.jsx" icon="icons/jsEditorIcon.png"/>
      <icon contentType="org.eclipse.wildwebdeveloper.ts" icon="icons/tsEditorIcon.png"/>
+     <icon contentType="org.eclipse.wildwebdeveloper.tsx" icon="icons/tsEditorIcon.png"/>
    </extension>
 
    <!-- Angular -->


### PR DESCRIPTION
JSX and TSX are extensions of JS and TS respectively, it makes sense to use their icons rather than falling back to the default generic editor icon.