### PR TITLE
Correct file extensions/names/patterns: ESLint, TypeScript config/lint

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -57,8 +57,8 @@
       </content-type>
       <content-type
             base-type="org.eclipse.wildwebdeveloper.json"
-            file-extensions="*.eslintrc.json"
-            file-names=".eslintrc,*.eslintrc.json"
+            file-extensions="eslintrc"
+            file-patterns="*.eslintrc.json"
             id="org.eclipse.wildwebdeveloper.json.eslintrc"
             name="ESLint Configuration"
             priority="normal">
@@ -94,8 +94,7 @@
       <content-type
             base-type="org.eclipse.wildwebdeveloper.json"
             file-names="tsconfig.json"
-            file-patterns="tsconfig.*.json"
-            file-extensions="*.tsconfig.json"
+            file-patterns="*.tsconfig.json,tsconfig.*.json,tsconfig-*.json"
             id="org.eclipse.wildwebdeveloper.json.tsconfig"
             name="TypeScript Configuration"
             priority="normal">
@@ -103,7 +102,7 @@
       <content-type
             base-type="org.eclipse.wildwebdeveloper.json"
             file-names="tslint.json"
-            file-extensions="*.tslint.json"
+            file-patterns="*.tslint.json"
             id="org.eclipse.wildwebdeveloper.json.tslint"
             name="TSLint Configuration"
             priority="normal">


### PR DESCRIPTION
In the [`org.eclipse.core.contenttype.contentTypes` extension point](https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/reference/extension-points/org_eclipse_core_contenttype_contentTypes.html), the `file-extensions` attribute must not contain `.` and `*` since _extension_ means here the string after the last `.` and the `file-names` attribute does not support the `*` wildcard in contrast to the `file-patterns` attribute.

Examples:
- `file-extensions="eslintrc"` matches the following file names: `.eslintrc`, `foo.eslintrc`, etc.
- `file-patterns="*.eslintrc.json"` matches the following file names: `.eslintrc.json`, `foo.eslintrc.json`, etc.
- `file-extensions="eslintrc.json"` does not match any filename