### PR TITLE
XML: Add dependency to org.eclipse.tm4e.languageconfiguration

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.xml/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Automatic-Module-Name: org.eclipse.wildwebdeveloper.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.tm4e.registry;bundle-version="0.3.0",
  org.eclipse.tm4e.ui;bundle-version="0.1.0",
+ org.eclipse.tm4e.languageconfiguration;bundle-version="0.1.0",
  org.eclipse.lsp4e;bundle-version="0.13.4",
  org.eclipse.lsp4j;bundle-version="0.9.0",
  org.eclipse.core.filesystem;bundle-version="1.7.0",


### PR DESCRIPTION
The `org.eclipse.tm4e.languageconfiguration` is required for the `org.eclipse.tm4e.languageconfiguration.languageConfigurations`
extension point and to avoid errors in the preferences _Text Mate > Language Configuration_ when e.g. in the Eclipse SDK, only the _Wild Web Developer XML tools_ feature is installed.

See also [commit 76a939bdf0fc9d06d5cf2f51fa9971c6d4a06777](https://github.com/eclipse/wildwebdeveloper/commit/76a939bdf0fc9d06d5cf2f51fa9971c6d4a06777)