### PR TITLE
Fix github credencials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ spec:
 	environment {
 		NPM_CONFIG_USERCONFIG = "$WORKSPACE/.npmrc"
 		MAVEN_OPTS="-Xmx1024m"
+		GITHUB_API_CREDENTIALS_ID = 'github-bot-token'
 	}
 	stages {
 		stage('Prepare-environment') {
@@ -53,8 +54,10 @@ spec:
 		stage('Build') {
 			steps {
 				container('container') {
-					wrap([$class: 'Xvnc', useXauthority: true]) {
-						sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+					withCredentials([string(credentialsId: "${GITHUB_API_CREDENTIALS_ID}", variable: 'GITHUB_API_TOKEN')]) {
+						wrap([$class: 'Xvnc', useXauthority: true]) {
+							sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+						}
 					}
 				}
 			}

--- a/org.eclipse.wildwebdeveloper.feature/feature.xml
+++ b/org.eclipse.wildwebdeveloper.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.wildwebdeveloper.feature"
       label="%name"
-      version="0.10.13.qualifier"
+      version="0.10.14.qualifier"
       provider-name="Eclipse Wild Web Developer project"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.wildwebdeveloper.feature/pom.xml
+++ b/org.eclipse.wildwebdeveloper.feature/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-feature</packaging>
-	<version>0.10.13-SNAPSHOT</version>
+	<version>0.10.14-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.5.21.qualifier
+Bundle-Version: 0.5.22.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.5.21-SNAPSHOT</version>
+	<version>0.5.22-SNAPSHOT</version>
 
 	<build>
 		<plugins>
@@ -93,6 +93,9 @@
 							<skipCache>true</skipCache>
 							<url>https://raw.githubusercontent.com/microsoft/vscode-eslint/release/2.2.2/server/package.json</url>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls/extension/server</outputDirectory>
+							<headers>
+								<Authorization>${GITHUB_API_TOKEN}</Authorization>
+							</headers>
 						</configuration>
 					</execution>
 				</executions>

--- a/repository/epp.product
+++ b/repository/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for JavaScript and Web Developers" uid="org.eclipse.wildwebdeveloper.product" id="org.eclipse.wildwebdeveloper.product.branding.product" application="org.eclipse.ui.ide.workbench" version="0.13.4.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for JavaScript and Web Developers" uid="org.eclipse.wildwebdeveloper.product" id="org.eclipse.wildwebdeveloper.product.branding.product" application="org.eclipse.ui.ide.workbench" version="0.13.5.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.wildwebdeveloper.product.branding.product/eclipse_lg.png"/>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-repository</packaging>
-	<version>0.13.4-SNAPSHOT</version>
+	<version>0.13.5-SNAPSHOT</version>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Github project credentials are to be used in `wget` action when accessing
`https://raw.githubusercontent.com` in order to minimize restriction limits

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>