### PR TITLE
Fix github credencials (pass 2)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ spec:
 				container('container') {
 					withCredentials([string(credentialsId: "${GITHUB_API_CREDENTIALS_ID}", variable: 'GITHUB_API_TOKEN')]) {
 						wrap([$class: 'Xvnc', useXauthority: true]) {
-							sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+							sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dgithub.api.token="${GITHUB_API_TOKEN}"'
 						}
 					}
 				}

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -94,7 +94,7 @@
 							<url>https://raw.githubusercontent.com/microsoft/vscode-eslint/release/2.2.2/server/package.json</url>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls/extension/server</outputDirectory>
 							<headers>
-								<Authorization>${GITHUB_API_TOKEN}</Authorization>
+								<Authorization>${github.api.token}</Authorization>
 							</headers>
 						</configuration>
 					</execution>


### PR DESCRIPTION
Github project credentials are to be used in `wget` action when accessing
`https://raw.githubusercontent.com` in order to minimize restriction limits

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>