### PR TITLE
Fix github credencials (pass 3)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 1, unit: 'HOURS')
+		timeout(time: 2, unit: 'HOURS')
 		buildDiscarder(logRotator(numToKeepStr:'10'))
 	}
   agent {
@@ -56,7 +56,7 @@ spec:
 				container('container') {
 					withCredentials([string(credentialsId: "${GITHUB_API_CREDENTIALS_ID}", variable: 'GITHUB_API_TOKEN')]) {
 						wrap([$class: 'Xvnc', useXauthority: true]) {
-							sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dgithub.api.token="${GITHUB_API_TOKEN}"'
+							sh 'mvn clean verify -B -Dtycho.disableP2Mirrors=true -Ddownload.cache.skip=true -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -PpackAndSign -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dgithub.api.token="${GITHUB_API_TOKEN}" -Puse-github-api-token'
 						}
 					}
 				}

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -9,6 +9,35 @@
 	<packaging>eclipse-plugin</packaging>
 	<version>0.5.22-SNAPSHOT</version>
 
+	<profiles>
+		<profile>
+			<id>use-github-api-token</id>
+			<activation>
+				<property>
+					<name>github.api.token</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.maven-download-plugin</groupId>
+						<artifactId>download-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>fetch-eslint-ls-package.json</id>
+								<configuration>
+									<headers>
+										<Authorization>token ${github.api.token}</Authorization>
+									</headers>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	
 	<build>
 		<plugins>
 			<plugin>
@@ -93,9 +122,6 @@
 							<skipCache>true</skipCache>
 							<url>https://raw.githubusercontent.com/microsoft/vscode-eslint/release/2.2.2/server/package.json</url>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls/extension/server</outputDirectory>
-							<headers>
-								<Authorization>${github.api.token}</Authorization>
-							</headers>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Github project credentials are to be used in `wget` action when accessing
`https://raw.githubusercontent.com` in order to minimize restriction limits

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>