### PR TITLE
Kill zombie process in tests

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for WildWebDeveloper
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.tests;singleton:=true
-Bundle-Version: 0.4.17.qualifier
+Bundle-Version: 0.4.18.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -23,5 +23,6 @@ Require-Bundle: org.eclipse.wildwebdeveloper;bundle-version="0.5.19",
  org.eclipse.debug.ui,
  org.eclipse.core.filesystem,
  org.eclipse.ui.editors,
- org.eclipse.ui.console;bundle-version="3.11.0"
+ org.eclipse.ui.console;bundle-version="3.11.0",
+ org.eclipse.lsp4e.debug;bundle-version="0.13.0"
 Import-Package: org.eclipse.ui.editors.text

--- a/org.eclipse.wildwebdeveloper.tests/pom.xml
+++ b/org.eclipse.wildwebdeveloper.tests/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.4.17-SNAPSHOT</version>
+	<version>0.4.18-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestDebug.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestDebug.java
@@ -34,6 +34,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.core.model.ISuspendResume;
 import org.eclipse.debug.core.model.IThread;
 import org.eclipse.debug.core.model.IVariable;
@@ -80,6 +81,15 @@ public class TestDebug {
 				debugTarget.terminate();
 				launch.removeDebugTarget(debugTarget);
 			}
+			for (IProcess process : launch.getProcesses()) {
+				process.terminate();
+			}
+			// workaround that some debugger process don't terminate as expected
+			// LSP4E fixes it in later versions: https://github.com/eclipse/lsp4e/pull/122
+			ProcessHandle.current().descendants()
+					.filter(process -> process.info().commandLine()
+							.filter(command -> command.contains("node") && command.contains("debug")).isPresent())
+					.forEach(ProcessHandle::destroyForcibly);
 			launchManager.removeLaunch(launch);
 		}
 	}


### PR DESCRIPTION
node-debug doesn't react well to "destroy". LSP4E fixes it later with
https://github.com/eclipse/lsp4e/pull/122 , but in the meantime, we need
a workaround.