### PR TITLE
WARNING: Unsupported notification method: angular/NgccProgressEnd #832

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularClientImpl.java
@@ -44,6 +44,11 @@ public class AngularClientImpl extends LanguageClientImpl implements AngularLang
 	}
 	
 	@Override
+	public void ngccProgressEnd(Object o) {
+		logMessage(new MessageParams(MessageType.Info, o.toString()));
+	}
+	
+	@Override
 	public void notifyProgress(ProgressParams params) {
 		String message = null;
 		Either<WorkDoneProgressNotification, Object> either = params.getValue();
@@ -61,4 +66,5 @@ public class AngularClientImpl extends LanguageClientImpl implements AngularLang
 			logMessage(new MessageParams(MessageType.Info, params.getToken().getLeft()  + ": " + (message == null? "done":message)));
 		}
 	}
+
 }

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularLanguageServerExtention.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/angular/AngularLanguageServerExtention.java
@@ -20,4 +20,7 @@ public interface AngularLanguageServerExtention {
 
 	@JsonNotification(value = "angular/suggestIvyLanguageServiceMode")
 	public void suggestIvyLanguageServiceMode(Object o);
+	
+	@JsonNotification(value = "angular/NgccProgressEnd")
+	public void ngccProgressEnd(Object o);
 }


### PR DESCRIPTION
A default implementation is added for the `angular/NgccProgressEnd` notification method

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>