### PR TITLE
Update Embedded Node.js Runtime to latest LTS candidate version (v.18…

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Linux AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-arm64.tar.gz
-archiveFile=resources/node-v16.14.2-linux-arm64.tar.gz
-nodePath=node-v16.14.2-linux-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.8.0/node-v18.8.0-linux-arm64.tar.gz
+archiveFile=resources/node-v18.8.0-linux-arm64.tar.gz
+nodePath=node-v18.8.0-linux-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Linux x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-x64.tar.gz
-archiveFile=resources/node-v16.14.2-linux-x64.tar.gz
-nodePath=node-v16.14.2-linux-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.8.0/node-v18.8.0-linux-x64.tar.gz
+archiveFile=resources/node-v18.8.0-linux-x64.tar.gz
+nodePath=node-v18.8.0-linux-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for MacOS AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-darwin-arm64.tar.gz
-archiveFile=resources/node-v16.14.2-darwin-arm64.tar.gz
-nodePath=node-v16.14.2-darwin-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.8.0/node-v18.8.0-darwin-arm64.tar.gz
+archiveFile=resources/node-v18.8.0-darwin-arm64.tar.gz
+nodePath=node-v18.8.0-darwin-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.3-SNAPSHOT</version>
+	<version>0.1.4-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for MacOS x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64
-Bundle-Version: 0.1.9.qualifier
+Bundle-Version: 0.1.10.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-darwin-x64.tar.gz
-archiveFile=resources/node-v16.14.2-darwin-x64.tar.gz
-nodePath=node-v16.14.2-darwin-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.8.0/node-v18.8.0-darwin-x64.tar.gz
+archiveFile=resources/node-v18.8.0-darwin-x64.tar.gz
+nodePath=node-v18.8.0-darwin-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.9-SNAPSHOT</version>
+	<version>0.1.10-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Windows x86_64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-win-x64.zip
-archiveFile = resources/node-v16.14.2-win-x64.zip
-nodePath = node-v16.14.2-win-x64/node.exe
+archiveURL=https://nodejs.org/download/release/v18.8.0/node-v18.8.0-win-x64.zip
+archiveFile = resources/node-v18.8.0-win-x64.zip
+nodePath = node-v18.8.0-win-x64/node.exe

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>


### PR DESCRIPTION
….8.0)

Changelog: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.8.0

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>