### PR TITLE
Update VSCode extentions, LSs and NPM Nodules

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Linux AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-arm64.tar.gz
-archiveFile=resources/node-v16.14.2-linux-arm64.tar.gz
-nodePath=node-v16.14.2-linux-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.17.0/node-v16.17.0-linux-arm64.tar.gz
+archiveFile=resources/node-v16.17.0-linux-arm64.tar.gz
+nodePath=node-v16.17.0-linux-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Linux x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-linux-x64.tar.gz
-archiveFile=resources/node-v16.14.2-linux-x64.tar.gz
-nodePath=node-v16.14.2-linux-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.17.0/node-v16.17.0-linux-x64.tar.gz
+archiveFile=resources/node-v16.17.0-linux-x64.tar.gz
+nodePath=node-v16.17.0-linux-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for MacOS AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-darwin-arm64.tar.gz
-archiveFile=resources/node-v16.14.2-darwin-arm64.tar.gz
-nodePath=node-v16.14.2-darwin-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.17.0/node-v16.17.0-darwin-arm64.tar.gz
+archiveFile=resources/node-v16.17.0-darwin-arm64.tar.gz
+nodePath=node-v16.17.0-darwin-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.3-SNAPSHOT</version>
+	<version>0.1.4-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for MacOS x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64
-Bundle-Version: 0.1.9.qualifier
+Bundle-Version: 0.1.10.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-darwin-x64.tar.gz
-archiveFile=resources/node-v16.14.2-darwin-x64.tar.gz
-nodePath=node-v16.14.2-darwin-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.17.0/node-v16.17.0-darwin-x64.tar.gz
+archiveFile=resources/node-v16.17.0-darwin-x64.tar.gz
+nodePath=node-v16.17.0-darwin-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.9-SNAPSHOT</version>
+	<version>0.1.10-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Node.js for Windows x86_64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64
-Bundle-Version: 0.1.8.qualifier
+Bundle-Version: 0.1.9.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.14.2/node-v16.14.2-win-x64.zip
-archiveFile = resources/node-v16.14.2-win-x64.zip
-nodePath = node-v16.14.2-win-x64/node.exe
+archiveURL=https://nodejs.org/download/release/v16.17.0/node-v16.17.0-win-x64.zip
+archiveFile = resources/node-v16.17.0-win-x64.zip
+nodePath = node-v16.17.0-win-x64/node.exe

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/pom.xml
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.9-SNAPSHOT</version>
 	
 	 <build>
 		<plugins>

--- a/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Wild Web Developer: web development in Eclipse IDE
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper;singleton:=true
 Automatic-Module-Name: org.eclipse.wildwebdeveloper
-Bundle-Version: 0.6.1.qualifier
+Bundle-Version: 0.6.2.qualifier
 Bundle-Activator: org.eclipse.wildwebdeveloper.Activator
 Bundle-Vendor: Eclipse Wild Web Developer project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.5.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.6.1-SNAPSHOT</version>
+	<version>0.6.2-SNAPSHOT</version>
 
 	<build>
 		<plugins>
@@ -42,7 +42,7 @@
 						<configuration>
 							<connectionUrl>scm:git:https://github.com/microsoft/vscode-eslint.git</connectionUrl>
 							<scmVersionType>tag</scmVersionType>
-							<scmVersion>release/2.2.2</scmVersion>
+							<scmVersion>release/2.2.6</scmVersion>
 							<basedir>${project.build.directory}</basedir>
 							<checkoutDirectory>${project.build.directory}/vscode-eslint-ls-package-json/extension</checkoutDirectory>
 						</configuration>
@@ -60,7 +60,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://az764295.vo.msecnd.net/stable/dfd34e8260c270da74b5c2d86d61aee4b6d56977/code-stable-x64-1649664837.tar.gz</url>
+							<url>https://az764295.vo.msecnd.net/stable/e4503b30fc78200f846c62cf8091b76ff5547662/code-stable-x64-1660629670.tar.gz</url>
 							<unpack>true</unpack>
 							<outputDirectory>${project.build.directory}/vscode</outputDirectory>
 						</configuration>
@@ -98,7 +98,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-                            <url>https://dbaeumer.gallery.vsassets.io/_apis/public/gallery/publisher/dbaeumer/extension/vscode-eslint/2.2.3/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage</url>
+                            <url>https://dbaeumer.gallery.vsassets.io/_apis/public/gallery/publisher/dbaeumer/extension/vscode-eslint/2.2.6/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage</url>
 							<outputFileName>vscode-eslint-ls.zip</outputFileName>
 							<unpack>true</unpack>
 							<outputDirectory>${project.build.directory}/vscode-eslint-ls</outputDirectory>
@@ -204,18 +204,18 @@
 								<arg>--no-bin-links</arg>
 								<arg>--ignore-scripts</arg>
 								<arg>${project.build.directory}/node-debug2-1.43.0.tgz</arg>
-								<arg>typescript@4.6.4</arg>
-								<arg>typescript-language-server@0.9.7</arg>
+								<arg>typescript@4.8.3</arg>
+								<arg>typescript-language-server@1.2.0</arg>
 								<arg>typescript-lit-html-plugin@0.9.0</arg>
 								<arg>typescript-plugin-css-modules@3.4.0</arg>
 								<arg>${project.build.directory}/vscode-css-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-html-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-json-languageserver-1.3.4.tgz</arg>
-								<arg>yaml-language-server@1.7.0</arg>
-								<arg>firefox-debugadapter@2.9.6</arg>
+								<arg>yaml-language-server@1.10.0</arg>
+								<arg>firefox-debugadapter@2.9.8</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.13.0.tgz</arg>
-								<arg>${project.build.directory}/eslint-server-2.1.25.tgz</arg>
-								<arg>@angular/language-server@14.0.1</arg>
+								<arg>${project.build.directory}/eslint-server-2.2.5.tgz</arg>
+								<arg>@angular/language-server@14.2.0</arg>
 							</arguments>
 							<workingDirectory>${project.basedir}</workingDirectory>
 						</configuration>


### PR DESCRIPTION
    Update Vscode extensions
    
    vscode                        1.66.2 --> 1.70.2
    vscode-eslint                 2.2.2  --> 2.2.6
    eslint-server                 2.1.25 --> 2.2.5
    
    LSs & NPM Modules
    
    firefox-debugadapter          2.9.6  --> 2.9.8
    yaml-language-server          1.7.0  --> 1.10.0
    typescript                    4.6.4  --> 4.8.3
    typescript-language-server    0.9.7  --> 1.2.0
    angular/language-server       14.0.1 --> 14.2.0