### PR TITLE
Update LSs & NPM Modules - firefox-debugadapter 2.9.8

### DIFF
--- a/org.eclipse.wildwebdeveloper/pom.xml
+++ b/org.eclipse.wildwebdeveloper/pom.xml
@@ -212,7 +212,7 @@
 								<arg>${project.build.directory}/vscode-html-languageserver-1.0.0.tgz</arg>
 								<arg>${project.build.directory}/vscode-json-languageserver-1.3.4.tgz</arg>
 								<arg>yaml-language-server@1.7.0</arg>
-								<arg>firefox-debugadapter@2.9.6</arg>
+								<arg>firefox-debugadapter@2.9.8</arg>
 								<arg>${project.build.directory}/debugger-for-chrome-4.13.0.tgz</arg>
 								<arg>${project.build.directory}/eslint-server-2.1.25.tgz</arg>
 								<arg>@angular/language-server@14.0.1</arg>


### PR DESCRIPTION
    firefox-debugadapter          2.9.6  --> 2.9.8

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>