### PR TITLE
Update Embedded Node.js Runtime to latest LTS candidate version (v.18…

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-arm64.tar.gz
-archiveFile=resources/node-v16.17.1-linux-arm64.tar.gz
-nodePath=node-v16.17.1-linux-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.10.0/node-v18.10.0-linux-arm64.tar.gz
+archiveFile=resources/node-v18.10.0-linux-arm64.tar.gz
+nodePath=node-v18.10.0-linux-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-x64.tar.gz
-archiveFile=resources/node-v16.17.1-linux-x64.tar.gz
-nodePath=node-v16.17.1-linux-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.10.0/node-v18.10.0-linux-x64.tar.gz
+archiveFile=resources/node-v18.10.0-linux-x64.tar.gz
+nodePath=node-v18.10.0-linux-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz
-archiveFile=resources/node-v16.17.1-darwin-arm64.tar.gz
-nodePath=node-v16.17.1-darwin-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.10.0/node-v18.10.0-darwin-arm64.tar.gz
+archiveFile=resources/node-v18.10.0-darwin-arm64.tar.gz
+nodePath=node-v18.10.0-darwin-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-darwin-x64.tar.gz
-archiveFile=resources/node-v16.17.1-darwin-x64.tar.gz
-nodePath=node-v16.17.1-darwin-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v18.10.0/node-v18.10.0-darwin-x64.tar.gz
+archiveFile=resources/node-v18.10.0-darwin-x64.tar.gz
+nodePath=node-v18.10.0-darwin-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-win-x64.zip
-archiveFile = resources/node-v16.17.1-win-x64.zip
-nodePath = node-v16.17.1-win-x64/node.exe
+archiveURL=https://nodejs.org/download/release/v18.10.0/node-v18.10.0-win-x64.zip
+archiveFile = resources/node-v18.10.0-win-x64.zip
+nodePath = node-v18.10.0-win-x64/node.exe


### PR DESCRIPTION
….10.0)

Changelog: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.10.0

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>