### PR TITLE
Update Embedded Node.js Runtime to latest LTS version (v.16.18.0)

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Node.js for Linux AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
-Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
+Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=aarch64))

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-arm64.tar.gz
-archiveFile=resources/node-v16.17.1-linux-arm64.tar.gz
-nodePath=node-v16.17.1-linux-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.18.0/node-v16.18.0-linux-arm64.tar.gz
+archiveFile=resources/node-v16.18.0-linux-arm64.tar.gz
+nodePath=node-v16.18.0-linux-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Node.js for Linux x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
-Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
+Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.linux
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86_64))

--- a/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.linux.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-x64.tar.gz
-archiveFile=resources/node-v16.17.1-linux-x64.tar.gz
-nodePath=node-v16.17.1-linux-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.18.0/node-v16.18.0-linux-x64.tar.gz
+archiveFile=resources/node-v16.18.0-linux-x64.tar.gz
+nodePath=node-v16.18.0-linux-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Node.js for MacOS AArch64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
-Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
+Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos
 Eclipse-PlatformFilter: (& (osgi.os=macosx) (osgi.arch=aarch64))

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz
-archiveFile=resources/node-v16.17.1-darwin-arm64.tar.gz
-nodePath=node-v16.17.1-darwin-arm64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.18.0/node-v16.18.0-darwin-arm64.tar.gz
+archiveFile=resources/node-v16.18.0-darwin-arm64.tar.gz
+nodePath=node-v16.18.0-darwin-arm64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Node.js for MacOS x64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
-Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
+Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.macos
 Eclipse-PlatformFilter: (& (osgi.os=macosx) (osgi.arch=x86_64))

--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-darwin-x64.tar.gz
-archiveFile=resources/node-v16.17.1-darwin-x64.tar.gz
-nodePath=node-v16.17.1-darwin-x64/bin/node
+archiveURL=https://nodejs.org/download/release/v16.18.0/node-v16.18.0-darwin-x64.tar.gz
+archiveFile=resources/node-v16.18.0-darwin-x64.tar.gz
+nodePath=node-v16.18.0-darwin-x64/bin/node

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Node.js for Windows x86_64
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
-Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="0.1.0"
+Fragment-Host: org.eclipse.wildwebdeveloper.embedder.node;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64
 Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.ws=win32) (osgi.arch=x86_64))

--- a/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
+++ b/org.eclipse.wildwebdeveloper.embedder.node.win32.x86_64/nodejs-info.properties
@@ -1,3 +1,3 @@
-archiveURL=https://nodejs.org/download/release/v16.17.1/node-v16.17.1-win-x64.zip
-archiveFile = resources/node-v16.17.1-win-x64.zip
-nodePath = node-v16.17.1-win-x64/node.exe
+archiveURL=https://nodejs.org/download/release/v16.18.0/node-v16.18.0-win-x64.zip
+archiveFile = resources/node-v16.18.0-win-x64.zip
+nodePath = node-v16.18.0-win-x64/node.exe


### PR DESCRIPTION
Changelog: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#16.18.0

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>