### PR TITLE
Syntax coloration / language config for DTD, RelaxNG

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@ This page describes the noteworthy improvements provided by each release of Ecli
 #### Editing improvements
   * XML auto closing tag
   * HTML auto closing tag and auto creation of quotes for HTML attribute assignment
+  * RelaxNG support : XML validation, completion hover based on RelaxNG schema  
+  * Syntax coloration for DTD
+  * Syntax coloration / language configuration for RelaxNG compact syntax (.rng)
 
 ## 0.15.1
 

--- a/org.eclipse.wildwebdeveloper.xml/grammars/dtd/dtd.tmLanguage.json
+++ b/org.eclipse.wildwebdeveloper.xml/grammars/dtd/dtd.tmLanguage.json
@@ -1,0 +1,47 @@
+{
+  "name": "DTD",
+  "scopeName": "text.xml.dtd",
+  "fileTypes": [
+    "dtd"
+  ],
+  "patterns": [
+    {
+      "begin": "(<!)(ELEMENT|ATTLIST|ENTITY|NOTATION)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.dtd"
+        },
+        "2": {
+          "name": "entity.name.tag.dtd"
+        }
+      },
+      "end": "\\s*(>)",
+      "name": "meta.tag.type.dtd",
+      "patterns": [
+        {
+          "match": "\\s+(CDATA|IDREFS|IDREF|ID|NMTOKENS|NMTOKEN|ENTITY|ENTITIES|NOTATION|SYSTEM|NDATA)",
+          "name": "keyword.other.data-type.dtd"
+        },
+        {
+          "match": "(#[A-Z]+)|(ANY)|(EMPTY)",
+          "name": "constant.language.dtd"
+        },
+        {
+          "begin": "'|\"",
+          "end": "'|\"",
+          "name": "string.quoted.double.dtd"
+        },
+        {
+          "begin": "(%[a-zA-Z][a-zA-Z0-9_-])",
+          "end": ";",
+          "name": "variable.language.dtd"
+        }
+      ]
+    },
+    {
+      "begin": "(<!--)",
+      "end": "(-->)",
+      "name": "comment.block.dtd"
+    }
+  ]
+}

--- a/org.eclipse.wildwebdeveloper.xml/grammars/rnc/rnc.tmLanguage.json
+++ b/org.eclipse.wildwebdeveloper.xml/grammars/rnc/rnc.tmLanguage.json
@@ -1,0 +1,86 @@
+{
+	"fileTypes": ["rnc"],
+	"foldingStartMarker": "\\{\\s*$",
+	"foldingStopMarker": "^\\s*\\}",
+	"name": "RelaxNG Compact",
+	"patterns": [
+	{
+		"match": "\\bgrammar\\b",
+		"name": "keyword.other.grammar.rnc"
+	},
+	{
+		"match": "\\bstart\\b",
+		"name": "keyword.other.start.rnc"
+	},
+	{
+		"match": "\\b(text|empty|xsd\\:(int|integer|double|date(Time)?|time|string|decimal))\\b",
+		"name": "storage.type.rnc"
+	},
+	{
+		"captures":
+		{
+			"1":
+			{
+				"name": "keyword.other.attribute.rnc"
+			},
+			"2":
+			{
+				"name": "entity.other.attribute.rnc"
+			}
+		},
+		"match": "\\b(attribute)\\s+([a-zA-Z][-a-zA-Z_0-9]*)\\s*\\{",
+		"name": "meta.declaration.attribute.rnc"
+	},
+	{
+		"captures":
+		{
+			"1":
+			{
+				"name": "keyword.other.element.rnc"
+			},
+			"2":
+			{
+				"name": "entity.other.element.rnc"
+			}
+		},
+		"match": "\\b(element)\\s+([a-zA-Z][-a-zA-Z_0-9]*)\\s*\\{",
+		"name": "meta.declaration.element.rnc"
+	},
+	{
+		"match": "#.*$",
+		"name": "comment.hash.rnc"
+	},
+	{
+		"begin": "\"",
+		"end": "\"",
+		"name": "string.quoted.double.rnc",
+		"patterns": [
+		{
+			"match": "\\\\.",
+			"name": "constant.character.escape.rnc"
+		}]
+	},
+	{
+		"begin": "'",
+		"end": "'",
+		"name": "string.quoted.single.rnc",
+		"patterns": [
+		{
+			"match": "\\\\.",
+			"name": "constant.character.escape.rnc"
+		}]
+	},
+	{
+		"captures":
+		{
+			"1":
+			{
+				"name": "entity.other.grammar_production.rnc"
+			}
+		},
+		"match": "\\b([a-zA-Z][a-zA-Z_0-9]*)\\s*=",
+		"name": "meta.grammar_production.rnc"
+	}],
+	"scopeName": "source.rnc",
+	"uuid": "85F32571-780F-4AAC-BA70-C2229E0B1BDA"
+}

--- a/org.eclipse.wildwebdeveloper.xml/language-configurations/rnc/rnc.language-configuration.json
+++ b/org.eclipse.wildwebdeveloper.xml/language-configurations/rnc/rnc.language-configuration.json
@@ -1,0 +1,28 @@
+// Copy of https://github.com/RussGlover/relaxNgCompactSyntaxHighlighter/blob/master/language-configuration.json
+{
+  "comments": {
+      "lineComment": "#"
+  },
+  // symbols used as brackets
+  "brackets": [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"],
+      ["\"", "\""],
+      ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+      ["{", "}"],
+      ["[", "]"],
+      ["(", ")"],
+      ["\"", "\""],
+      ["'", "'"]
+  ]
+}

--- a/org.eclipse.wildwebdeveloper.xml/plugin.xml
+++ b/org.eclipse.wildwebdeveloper.xml/plugin.xml
@@ -8,6 +8,10 @@
             contentTypeId="org.eclipse.core.runtime.xml"
             editorId="org.eclipse.ui.genericeditor.GenericEditor">
       </editorContentTypeBinding>
+       <editorContentTypeBinding
+            contentTypeId="org.eclipse.wildwebdeveloper.rnc"
+            editorId="org.eclipse.ui.genericeditor.GenericEditor">
+      </editorContentTypeBinding>
    </extension>
 
    <extension
@@ -15,6 +19,10 @@
       <presentationReconciler
             class="org.eclipse.tm4e.ui.text.TMPresentationReconciler"
             contentType="org.eclipse.core.runtime.xml">
+      </presentationReconciler>
+      <presentationReconciler
+            class="org.eclipse.tm4e.ui.text.TMPresentationReconciler"
+            contentType="org.eclipse.wildwebdeveloper.rnc">
       </presentationReconciler>
    </extension>
 
@@ -50,6 +58,21 @@
             name="DTD"
             priority="normal">
       </content-type>
+      <!-- RelaxNG -->
+      <content-type
+            base-type="org.eclipse.core.runtime.xml"
+            file-extensions="rng"
+            id="org.eclipse.wildwebdeveloper.rng"
+            name="RNG"
+            priority="normal">
+      </content-type>
+      <content-type
+            base-type="org.eclipse.core.runtime.text"
+            file-extensions="rnc"
+            id="org.eclipse.wildwebdeveloper.rnc"
+            name="RNC"
+            priority="normal">
+      </content-type>
    </extension>
    
    <extension
@@ -78,6 +101,10 @@
             contentType="org.eclipse.wildwebdeveloper.dtd"
             id="org.eclipse.wildwebdeveloper.xml">
       </contentTypeMapping>
+      <contentTypeMapping
+            contentType="org.eclipse.wildwebdeveloper.rng"
+            id="org.eclipse.wildwebdeveloper.xml">
+      </contentTypeMapping>      
    </extension>
  
    <extension
@@ -85,6 +112,14 @@
       <grammar
             path="grammars/xml/xml.tmLanguage.json"
             scopeName="source.xml">
+      </grammar>
+      <grammar
+            path="grammars/dtd/dtd.tmLanguage.json"
+            scopeName="text.xml.dtd">
+      </grammar>
+            <grammar
+            path="grammars/rnc/rnc.tmLanguage.json"
+            scopeName="source.rnc">
       </grammar>
       <scopeNameContentTypeBinding
             contentTypeId="org.eclipse.core.runtime.xml"
@@ -104,7 +139,11 @@
       </scopeNameContentTypeBinding>
       <scopeNameContentTypeBinding
             contentTypeId="org.eclipse.wildwebdeveloper.dtd"
-            scopeName="source.xml">
+            scopeName="text.xml.dtd">
+      </scopeNameContentTypeBinding>
+      <scopeNameContentTypeBinding
+            contentTypeId="org.eclipse.wildwebdeveloper.rnc"
+            scopeName="source.rnc">
       </scopeNameContentTypeBinding>
    </extension>
    
@@ -117,6 +156,10 @@
       <languageConfiguration
             contentTypeId="org.eclipse.wildwebdeveloper.xsl"
             path="language-configurations/xsl/xsl.language-configuration.json">
+      </languageConfiguration>
+      <languageConfiguration
+            contentTypeId="org.eclipse.wildwebdeveloper.rnc"
+            path="language-configurations/rnc/rnc.language-configuration.json">
       </languageConfiguration>
    </extension>
    
@@ -131,7 +174,7 @@
    <extension
          point="org.eclipse.ui.genericeditor.icons">
       <icon
-            contentType="org.eclipse.wildwebdeveloper.xml"
+            contentType="org.eclipse.core.runtime.xml"
             icon="icons/xmlEditorIcon.png">
       </icon>
    </extension>


### PR DESCRIPTION
This PR provides

 * syntax coloration for DTD

![image](https://user-images.githubusercontent.com/1932211/196637071-514c813d-90b5-45c5-93da-7bc5e459ec63.png)

 * syntax coloration + language configuration for RelaxNG compact syntax

![image](https://user-images.githubusercontent.com/1932211/196637256-bc990456-4c17-4b57-ae48-99a1fd75afec.png)

 * Defines the RNG (RelaxNG XML syntax) , RNC (RelaxNG compact syntax) content type.
 * Bind RNG files with XML language server to support RelaxNG validation/completion, hover for a RelaxNG RNG grammar file. This feature will be available when LemMinx release (which sould come from today I hope) will be embed in WWD.

If you don't know about RelaxNG, see the vscode-xml documentation at https://github.com/redhat-developer/vscode-xml/blob/main/docs/Features/RelaxNGFeatures.md and in https://github.com/redhat-developer/vscode-xml/blob/main/docs/Features/RelaxNGFeatures.md#creating-xml-rng-rnc-files you have samples of RNG, RNC and XML validated by RelaxNG files.
