### PR TITLE
Fix absent distribution param in setup-java in WindowsPR

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/windowsPR.yml
+++ b/.github/workflows/windowsPR.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 17
+        distribution: 'temurin'
     - uses: actions/setup-node@v1
       with:
         node-version: '16'


### PR DESCRIPTION
Also moved distribution from 'adopt' to 'temurin' -
see: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/