### PR TITLE
Fix absent distribution param in setup-java in WindowsPR + v3

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/windowsPR.yml
+++ b/.github/workflows/windowsPR.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 17
+        distribution: 'temurin'
     - uses: actions/setup-node@v1
       with:
         node-version: '16'


### PR DESCRIPTION
Also moved distribution from 'adopt' to 'temurin' -
see: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/