### PR TITLE
Fix JS/TS Refactoring Rename JUnit Test

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/.classpath
+++ b/org.eclipse.wildwebdeveloper.tests/.classpath
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wildwebdeveloper.tests/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for WildWebDeveloper
 Bundle-SymbolicName: org.eclipse.wildwebdeveloper.tests;singleton:=true
-Bundle-Version: 1.0.1.qualifier
+Bundle-Version: 1.0.2.qualifier
 Bundle-Vendor: Eclipse Wild Web Developer
 Automatic-Module-Name: org.eclipse.wildwebdeveloper.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.wildwebdeveloper;bundle-version="0.5.19",
+Require-Bundle: org.eclipse.wildwebdeveloper;bundle-version="1.0.0",
  junit-jupiter-api;bundle-version="5.6.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/org.eclipse.wildwebdeveloper.tests/pom.xml
+++ b/org.eclipse.wildwebdeveloper.tests/pom.xml
@@ -7,7 +7,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.0.2-SNAPSHOT</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestJsTs.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestJsTs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Red Hat Inc. and others.
+ * Copyright (c) 2018, 2022 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.PlatformUI;
@@ -104,10 +105,15 @@ public class TestJsTs {
 		AtomicBoolean renameDialogContinuePressed = new AtomicBoolean();
 		AtomicBoolean renameDialogCancelPressed = new AtomicBoolean();
 		AtomicBoolean errorDialogOkPressed = new AtomicBoolean();
+		AtomicBoolean newTextIsSet = new AtomicBoolean();
+
 		Listener pressOKonRenameDialogPaint = event -> {
 			if (event.widget instanceof Composite c) {
 				Shell shell = c.getShell();
 				if (shell != ideShell && shell.getData().getClass().getName().startsWith(WIZARD_CLASSNAME_TEMPLATE)) {
+					if (!newTextIsSet.get()) {
+						newTextIsSet.set(setNewText(c, newName));
+					}
 					Set<String> buttons = getButtons(c);
 					if (WIZARD_RENAME.equals(shell.getText())) {
 						if (!renameDialogOkPressed.get()) {
@@ -167,6 +173,26 @@ public class TestJsTs {
 		} else if (w instanceof Composite composite) {
 			for (Control child : composite.getChildren()) {
 				result.addAll(getButtons(child));
+			}
+		}
+		return result;
+	}
+
+	static private boolean setNewText(Widget w, String newText) {
+		Set<Text> textWidgets = getTextWidgets(w);
+		if (!textWidgets.isEmpty()) {
+			textWidgets.forEach(t -> t.setText(newText));
+		}
+		return false;
+	}
+
+	static private Set<Text> getTextWidgets(Widget w) {
+		Set<Text> result = new HashSet<>();
+		if (w instanceof Text text) {
+			result.add(text);
+		} else if (w instanceof Composite composite) {
+			for (Control child : composite.getChildren()) {
+				result.addAll(getTextWidgets(child));
 			}
 		}
 		return result;


### PR DESCRIPTION
Due to change in  `typescript-language-server@2.2.0` that implements `prepareRename` request now we have to implicitly set the new value for an identofier im `Refactoring->Rename` dialog during the test.

See: [`feat: support textDocument/prepareRename request #628` change](https://github.com/typescript-language-server/typescript-language-server/pull/628)  
