### PR TITLE
Fix Unsupported notification method: $/typescriptVersion

### DIFF
--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -534,6 +534,7 @@
          point="org.eclipse.lsp4e.languageServer">
       <server
             class="org.eclipse.wildwebdeveloper.jsts.JSTSLanguageServer"
+            clientImpl="org.eclipse.wildwebdeveloper.jsts.JSTSLanguageClientImpl"
             id="org.eclipse.wildwebdeveloper.jsts"
             label="JavaScript-TypeScript Language Server">
       </server>

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/JSTSLanguageClientImpl.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/jsts/JSTSLanguageClientImpl.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Victor Rubezhny (Red Hat Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.jsts;
+
+import java.util.Map;
+
+import org.eclipse.lsp4e.LanguageClientImpl;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+
+public class JSTSLanguageClientImpl extends LanguageClientImpl {
+
+	@JsonNotification(value = "$/typescriptVersion")
+	public void typescriptVersion(Map<String, String> tsInfo) {
+		logMessage(new MessageParams(MessageType.Info,
+				"Typescript Server version info: " + (tsInfo != null ? tsInfo.toString() : "not provided")));
+	}
+}


### PR DESCRIPTION
Feb 07, 2023 1:10:48 AM org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint notify
INFO: Unsupported notification method: $/typescriptVersion