### PR TITLE
[tests] Use Node v.18.16.0 on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ kind: Pod
 spec:
   containers:
   - name: container
-    image: docker.io/mickaelistria/fedora-gtk3-mutter-java-node:java-17
+    image: docker.io/vrubezhny/fedora-gtk3-mutter-java-node:java-17-node-18
     imagePullPolicy: Always
     tty: true
     command: [ "uid_entrypoint", "cat" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,9 @@ RUN dnf -y update && dnf -y install \
 	nodejs npm
 RUN dnf -y install xz
 
-RUN curl -L https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz | tar -xJ
+RUN curl -L https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz | tar -xJ
 
-ENV PATH=/node-v16.13.0-linux-x64/bin:/usr/lib/jvm/java-17/bin:$PATH
+ENV PATH=/node-v18.16.0-linux-x64/bin:/usr/lib/jvm/java-17/bin:$PATH
 ENV JAVA_HOME=/usr/lib/jvm/java-17
 
 #Back to named user

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ podman run USER_NAME/fedora-gtk3-mutter-java-node:latest  npm --version
 * Assign a tag to the image
 
 ```
-podman tag localhost/USER_NAME/fedora-gtk3-mutter-java-node:latest docker.io/vrubezhny/fedora-gtk3-mutter-java-node:TAG
+podman tag localhost/USER_NAME/fedora-gtk3-mutter-java-node:latest docker.io/USER_NAME/fedora-gtk3-mutter-java-node:TAG
 ```
 
 * Login


### PR DESCRIPTION
There is "Unsupported engine" error message during the tests projects setup:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'lru-cache@9.1.1',
npm WARN EBADENGINE   required: { node: '14 || >=16.14' },
npm WARN EBADENGINE   current: { node: 'v16.13.0', npm: '9.5.1' }
npm WARN EBADENGINE }
```
