### PR TITLE
[build] Fixed docker image to provide maven v.3.9.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,13 +4,15 @@ FROM eclipsecbi/fedora-gtk3-mutter:36-gtk3.24
 USER 0
 RUN dnf -y update && dnf -y install \
 	java-17-openjdk-devel maven git
-RUN dnf -y update && dnf -y install \
-	nodejs npm
+RUN dnf -y install nodejs npm
 RUN dnf -y install xz
+RUN dnf -y install procps-ng
+
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz | tar -xzv 
 
 RUN curl -L https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz | tar -xJ
 
-ENV PATH=/node-v18.16.0-linux-x64/bin:/usr/lib/jvm/java-17/bin:$PATH
+ENV PATH=/apache-maven-3.9.2/bin:/node-v18.16.0-linux-x64/bin:/usr/lib/jvm/java-17/bin:$PATH
 ENV JAVA_HOME=/usr/lib/jvm/java-17
 
 #Back to named user


### PR DESCRIPTION
due to the following build errors:
```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT:process (default-process) on project org.eclipse.wildwebdeveloper.embedder.node: The plugin org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT requires Maven version 3.8.6 -> [Help 1]
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT:process (default-process) on project org.eclipse.wildwebdeveloper.xml: The plugin org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT requires Maven version 3.8.6 -> [Help 1]
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT:process (default-process) on project org.eclipse.wildwebdeveloper.product.branding: The plugin org.eclipse.tycho:tycho-bnd-plugin:4.0.0-SNAPSHOT requires Maven version 3.8.6 -> [Help 1]
```